### PR TITLE
Add Taihu Casino SVG artwork asset

### DIFF
--- a/taihu-casino.svg
+++ b/taihu-casino.svg
@@ -1,0 +1,79 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 800" role="img" aria-label="Taihu Casino neon logo">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#091427"/>
+      <stop offset="100%" stop-color="#1c0936"/>
+    </linearGradient>
+    <linearGradient id="neon" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#6ff3ff"/>
+      <stop offset="50%" stop-color="#57ff8f"/>
+      <stop offset="100%" stop-color="#ffd86f"/>
+    </linearGradient>
+    <radialGradient id="chip" cx="50%" cy="50%" r="58%">
+      <stop offset="0%" stop-color="#ff6a7b"/>
+      <stop offset="100%" stop-color="#bf173f"/>
+    </radialGradient>
+    <filter id="glow" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="6" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    <pattern id="felt" width="16" height="16" patternUnits="userSpaceOnUse">
+      <rect width="16" height="16" fill="#0f5334"/>
+      <circle cx="4" cy="4" r="1" fill="#11693f"/>
+      <circle cx="12" cy="12" r="1" fill="#11693f"/>
+    </pattern>
+  </defs>
+
+  <rect width="1200" height="800" fill="url(#bg)"/>
+  <rect x="120" y="465" width="960" height="230" rx="28" fill="url(#felt)" opacity="0.92"/>
+
+  <g filter="url(#glow)">
+    <text x="600" y="235" text-anchor="middle" font-size="120" font-family="'Trebuchet MS', 'Segoe UI', sans-serif" font-weight="700" fill="url(#neon)">
+      TAIHU CASINO
+    </text>
+  </g>
+
+  <text x="600" y="292" text-anchor="middle" font-size="34" letter-spacing="8" font-family="'Segoe UI', sans-serif" fill="#d8f9ff" opacity="0.88">
+    MACAU STYLE • LUCK &amp; GLORY
+  </text>
+
+  <g transform="translate(245 170) rotate(-9)">
+    <rect x="0" y="0" width="140" height="200" rx="14" fill="#ffffff"/>
+    <rect x="8" y="8" width="124" height="184" rx="10" fill="#fdf6ec"/>
+    <text x="20" y="44" font-size="34" font-family="Georgia, serif" fill="#c10039">A</text>
+    <text x="70" y="130" font-size="84" text-anchor="middle" font-family="'Segoe UI Symbol','Noto Color Emoji',sans-serif" fill="#c10039">♥</text>
+    <text x="120" y="182" font-size="34" text-anchor="end" font-family="Georgia, serif" fill="#c10039">A</text>
+  </g>
+
+  <g transform="translate(816 186) rotate(8)">
+    <rect x="0" y="0" width="140" height="200" rx="14" fill="#ffffff"/>
+    <rect x="8" y="8" width="124" height="184" rx="10" fill="#eef7ff"/>
+    <text x="20" y="44" font-size="34" font-family="Georgia, serif" fill="#1645a7">K</text>
+    <text x="70" y="130" font-size="84" text-anchor="middle" font-family="'Segoe UI Symbol','Noto Color Emoji',sans-serif" fill="#1645a7">♠</text>
+    <text x="120" y="182" font-size="34" text-anchor="end" font-family="Georgia, serif" fill="#1645a7">K</text>
+  </g>
+
+  <g transform="translate(482 585)">
+    <circle cx="0" cy="0" r="78" fill="url(#chip)"/>
+    <circle cx="0" cy="0" r="58" fill="#ff8c99" opacity="0.38"/>
+    <circle cx="0" cy="0" r="70" fill="none" stroke="#ffd7dd" stroke-width="6" stroke-dasharray="8 12"/>
+    <text x="0" y="14" text-anchor="middle" font-size="30" font-family="'Segoe UI', sans-serif" fill="#fff3f4">1000</text>
+  </g>
+
+  <g transform="translate(626 575)">
+    <circle cx="0" cy="0" r="88" fill="#1d57c9"/>
+    <circle cx="0" cy="0" r="66" fill="#79a8ff" opacity="0.35"/>
+    <circle cx="0" cy="0" r="80" fill="none" stroke="#deebff" stroke-width="6" stroke-dasharray="9 13"/>
+    <text x="0" y="14" text-anchor="middle" font-size="32" font-family="'Segoe UI', sans-serif" fill="#edf5ff">5000</text>
+  </g>
+
+  <g transform="translate(770 592)">
+    <circle cx="0" cy="0" r="70" fill="#1d9e62"/>
+    <circle cx="0" cy="0" r="52" fill="#8ee3bb" opacity="0.33"/>
+    <circle cx="0" cy="0" r="62" fill="none" stroke="#dcffe9" stroke-width="6" stroke-dasharray="7 11"/>
+    <text x="0" y="12" text-anchor="middle" font-size="27" font-family="'Segoe UI', sans-serif" fill="#edfff5">100</text>
+  </g>
+</svg>


### PR DESCRIPTION
### Motivation
- Provide a reusable vector artwork for the project showcasing a Taihu Casino theme suitable for README or UI usage.
- Supply a standalone SVG asset that can be edited and embedded without additional raster images.

### Description
- Add `taihu-casino.svg`, a 1200×800 standalone SVG that renders a neon-style title, subtitle, playing cards, and three chips using gradients and patterns.
- The SVG includes definitions for gradients, a glow filter, and a felt pattern for the table area to keep the artwork fully vector and stylable.
- Fixed an XML well-formedness issue by escaping the ampersand in the subtitle (`LUCK &amp; GLORY`) so the file parses as valid XML.
- The file is self-contained and intended for direct reuse in documentation or the web UI.

### Testing
- Parsed the SVG with Python `xml.etree.ElementTree` to validate XML well-formedness, and the parse succeeded.
- Verified the repository now contains the new `taihu-casino.svg` asset (file added and recorded in version control).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c62eb664a483298afc845901b47ab7)