### PR TITLE
feat: add monochrome Taihu Casino wordmark SVG logo

### DIFF
--- a/taihu-casino-logo.svg
+++ b/taihu-casino-logo.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="400" viewBox="0 0 1600 400" role="img" aria-labelledby="title desc">
+  <title id="title">Taihu Casino Logo</title>
+  <desc id="desc">Monochrome wordmark logo for Taihu Casino.</desc>
+  <rect width="1600" height="400" fill="none" />
+  <text
+    x="800"
+    y="230"
+    text-anchor="middle"
+    font-family="'Helvetica Neue', Helvetica, Arial, 'Noto Sans', sans-serif"
+    font-size="150"
+    font-weight="700"
+    letter-spacing="10"
+    fill="#111111"
+  >
+    TAIHU CASINO
+  </text>
+</svg>


### PR DESCRIPTION
### Motivation
- 添加一个符合请求的纯色纯文字品牌字标 SVG，用于 Taihu Casino 的视觉资产，风格参考日系公司简洁纯文字标识。

### Description
- 新增 `taihu-casino-logo.svg`，画布 `1600x400`，透明背景，居中粗体字 `TAIHU CASINO`，字体栈 `"Helvetica Neue", Helvetica, Arial, "Noto Sans", sans-serif`，字号 `150`，字重 `700`，字距 `10`，颜色 `#111111`，并包含 `<title>` 与 `<desc>` 可访问性元数据。

### Testing
- 运行 `git status --short` 和 `nl -ba taihu-casino-logo.svg` 验证文件已创建并内容正确，命令均返回成功.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c63065d2008329923ad57e28bd2602)