### PR TITLE
[codex] Fix CI pnpm setup and member state handling / 修复 CI 与会员状态处理

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,11 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 24
-          cache: pnpm
 
       - name: Enable pnpm
-        run: corepack enable
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.33.0 --activate
 
       - name: Install
         run: pnpm install --frozen-lockfile

--- a/app/api/auth/logout/route.ts
+++ b/app/api/auth/logout/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server"
 import { cookies } from "next/headers"
 
+import { MEMBER_STATE_COOKIE } from "@/lib/member-data"
 import { createSupabaseAuthClient, isSupabaseAuthConfigured, MEMBER_SESSION_COOKIE } from "@/lib/server-auth"
 
 export async function POST() {
@@ -20,6 +21,13 @@ export async function POST() {
   }
 
   response.cookies.set(MEMBER_SESSION_COOKIE, "", {
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    path: "/",
+    maxAge: 0,
+  })
+  response.cookies.set(MEMBER_STATE_COOKIE, "", {
     httpOnly: true,
     sameSite: "lax",
     secure: process.env.NODE_ENV === "production",

--- a/lib/member-data.ts
+++ b/lib/member-data.ts
@@ -99,8 +99,11 @@ interface LocalMemberState {
   recentEvents?: MemberEvent[]
 }
 
-const MEMBER_STATE_COOKIE = "taihu-member-state"
+export const MEMBER_STATE_COOKIE = "taihu-member-state"
 const MEMBER_STATE_MAX_AGE_SECONDS = 60 * 60 * 24 * 30
+const LOCAL_STATE_PROGRESS_LIMIT = 4
+const LOCAL_STATE_EVENT_LIMIT = 3
+const LOCAL_STATE_SUMMARY_LIMIT = 120
 
 function nowIso() {
   return new Date().toISOString()
@@ -161,6 +164,21 @@ function writeLocalState(response: NextResponse, state: LocalMemberState) {
     path: "/",
     maxAge: MEMBER_STATE_MAX_AGE_SECONDS,
   })
+}
+
+function compactLocalProgress(progress: MemberGameProgress[]) {
+  return progress.slice(0, LOCAL_STATE_PROGRESS_LIMIT).map((item) => ({
+    ...item,
+    lastSummary: item.lastSummary.slice(0, LOCAL_STATE_SUMMARY_LIMIT),
+  }))
+}
+
+function compactLocalEvents(events: MemberEvent[]) {
+  return events.slice(0, LOCAL_STATE_EVENT_LIMIT).map((event) => ({
+    ...event,
+    title: event.title.slice(0, 80),
+    detail: event.detail.slice(0, LOCAL_STATE_SUMMARY_LIMIT),
+  }))
 }
 
 function defaultSettings(): MemberSettings {
@@ -610,7 +628,7 @@ export async function recordGameProgress(cookieStore: CookieStore, response: Nex
       throw new Error(error.message)
     }
 
-    await Promise.all([
+    const [walletResult, eventResult] = await Promise.all([
       auth.supabase.from("member_wallets").upsert({
         user_id: userId,
         currency: "USD",
@@ -623,6 +641,14 @@ export async function recordGameProgress(cookieStore: CookieStore, response: Nex
         detail: event.detail,
       }),
     ])
+
+    if (walletResult.error) {
+      throw new Error(walletResult.error.message)
+    }
+
+    if (eventResult.error) {
+      throw new Error(eventResult.error.message)
+    }
 
     return toProgress(data)
   }
@@ -660,8 +686,8 @@ export async function recordGameProgress(cookieStore: CookieStore, response: Nex
       balance: bankroll,
       updatedAt: playedAt,
     },
-    progress: progress.slice(0, 12),
-    recentEvents: [event, ...(state.recentEvents ?? [])].slice(0, 10),
+    progress: compactLocalProgress(progress),
+    recentEvents: compactLocalEvents([event, ...(state.recentEvents ?? [])]),
   })
 
   return nextProgress
@@ -674,7 +700,14 @@ export function isSameOriginMutation(request: Request) {
     return true
   }
 
-  const originUrl = new URL(origin)
+  let originUrl: URL
+
+  try {
+    originUrl = new URL(origin)
+  } catch {
+    return false
+  }
+
   const requestUrl = new URL(request.url)
 
   if (originUrl.origin === requestUrl.origin) {


### PR DESCRIPTION
﻿## Summary / 概要

Fix the CI pnpm setup order and close the remaining member-state review risks from the merged member-auth/game-table work.

修复 CI 中 pnpm 的启用顺序，并收口已合并会员认证/游戏桌工作里剩余的会员状态 review 风险。

## Changes / 改动内容

- Remove the failing `cache: pnpm` setup-node path and explicitly activate the repository pnpm version with Corepack before install.
- Clear the signed local member-state cookie during logout so local-auth accounts do not share stale progress/settings in the same browser.
- Guard malformed `Origin` headers in member mutation checks so bad input returns forbidden instead of throwing a 500.
- Check Supabase wallet/event mutation errors before returning successful game-progress writes.
- Trim local fallback progress/events before signing them into the cookie to reduce cookie-size failures.

- 移除会在 setup-node 阶段失败的 `cache: pnpm` 路径，并在安装依赖前通过 Corepack 显式启用仓库指定的 pnpm 版本。
- 登出时清理签名的本地会员状态 cookie，避免同一浏览器切换本地账号时串用旧进度/设置。
- 为会员 mutation 的 `Origin` 解析增加异常保护，让异常输入返回禁止访问，而不是变成 500。
- 在返回游戏进度写入成功前检查 Supabase 钱包/事件写入错误。
- 本地 fallback 写入 cookie 前裁剪进度/事件，降低超过 cookie 大小限制导致持久化失效的风险。

## Testing / 测试情况

- `corepack pnpm typecheck`
- `corepack pnpm build`
- `corepack pnpm lint` currently fails because `eslint` is not installed in this checkout's dependencies.

- 已运行 `corepack pnpm typecheck`
- 已运行 `corepack pnpm build`
- `corepack pnpm lint` 当前失败，原因是本仓库依赖中未安装 `eslint`。

## Notes / 备注

Opened as a draft so CI can confirm the workflow fix before merge.

先以草稿 PR 提交，便于等待 CI 验证 workflow 修复后再合并。
