### PR TITLE
[codex] Close GHO-19 backend wallet loop / 收口 GHO-19 后端钱包闭环

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ tsconfig.tsbuildinfo
 .preview-next*.log
 .preview-next*.err.log
 .playwright-cli/
+supabase/.temp/
 
 # Next.js / Node
 node_modules/

--- a/app/api/member/table-sessions/[id]/cash-out/route.ts
+++ b/app/api/member/table-sessions/[id]/cash-out/route.ts
@@ -1,0 +1,58 @@
+import { cookies } from "next/headers"
+import { NextResponse } from "next/server"
+
+import { cashOutTableSession, isSameOriginMutation } from "@/lib/member-data"
+
+export async function POST(
+  request: Request,
+  {
+    params,
+  }: {
+    params: Promise<{ id: string }>
+  },
+) {
+  if (!isSameOriginMutation(request)) {
+    return NextResponse.json({ error: "Cross-origin mutation rejected." }, { status: 403 })
+  }
+
+  const { id } = await params
+  const response = NextResponse.json(
+    { tableSession: null },
+    {
+      headers: {
+        "cache-control": "private, no-store",
+      },
+    },
+  )
+  const cookieStore = await cookies()
+  const body = await request.json().catch(() => null)
+
+  try {
+    const result = await cashOutTableSession(cookieStore, response, id, body)
+
+    if (!result) {
+      return NextResponse.json(
+        { error: "Authentication is required." },
+        {
+          status: 401,
+          headers: response.headers,
+        },
+      )
+    }
+
+    return NextResponse.json(
+      result,
+      {
+        headers: response.headers,
+      },
+    )
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Unable to cash out table session." },
+      {
+        status: 400,
+        headers: response.headers,
+      },
+    )
+  }
+}

--- a/app/api/member/table-sessions/active/route.ts
+++ b/app/api/member/table-sessions/active/route.ts
@@ -1,0 +1,47 @@
+import { cookies } from "next/headers"
+import { NextResponse } from "next/server"
+
+import { readActiveTableSession } from "@/lib/member-data"
+
+export async function GET(request: Request) {
+  const response = NextResponse.json(
+    { tableSession: null },
+    {
+      headers: {
+        "cache-control": "private, no-store",
+      },
+    },
+  )
+  const cookieStore = await cookies()
+  const { searchParams } = new URL(request.url)
+  const gameSlug = searchParams.get("gameSlug")?.trim() ?? ""
+
+  if (!gameSlug) {
+    return NextResponse.json(
+      { error: "Game slug is required." },
+      {
+        status: 400,
+        headers: response.headers,
+      },
+    )
+  }
+
+  try {
+    const tableSession = await readActiveTableSession(cookieStore, gameSlug, response)
+
+    return NextResponse.json(
+      { tableSession },
+      {
+        headers: response.headers,
+      },
+    )
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Unable to read table session." },
+      {
+        status: 400,
+        headers: response.headers,
+      },
+    )
+  }
+}

--- a/app/api/member/table-sessions/route.ts
+++ b/app/api/member/table-sessions/route.ts
@@ -1,0 +1,77 @@
+import { cookies } from "next/headers"
+import { NextResponse } from "next/server"
+
+import { isSameOriginMutation, openTableSession } from "@/lib/member-data"
+
+export async function POST(request: Request) {
+  if (!isSameOriginMutation(request)) {
+    return NextResponse.json({ error: "Cross-origin mutation rejected." }, { status: 403 })
+  }
+
+  const response = NextResponse.json(
+    { tableSession: null },
+    {
+      headers: {
+        "cache-control": "private, no-store",
+      },
+    },
+  )
+  const cookieStore = await cookies()
+  const contentType = request.headers.get("content-type") ?? ""
+  const acceptsHtml = request.headers.get("accept")?.includes("text/html") ?? false
+  const body = contentType.includes("application/json")
+    ? await request.json().catch(() => null)
+    : contentType.includes("form")
+      ? Object.fromEntries((await request.formData()).entries())
+      : null
+
+  try {
+    const result = await openTableSession(cookieStore, response, body)
+
+    if (!result) {
+      if (acceptsHtml) {
+        return NextResponse.redirect(new URL("/login?next=/games/baccarat", request.url), {
+          status: 303,
+          headers: response.headers,
+        })
+      }
+
+      return NextResponse.json(
+        { error: "Authentication is required." },
+        {
+          status: 401,
+          headers: response.headers,
+        },
+      )
+    }
+
+    if (acceptsHtml) {
+      return NextResponse.redirect(new URL(`/games/${result.tableSession.gameSlug}`, request.url), {
+        status: 303,
+        headers: response.headers,
+      })
+    }
+
+    return NextResponse.json(
+      result,
+      {
+        headers: response.headers,
+      },
+    )
+  } catch (error) {
+    if (acceptsHtml) {
+      return NextResponse.redirect(new URL("/games/baccarat?buyIn=error", request.url), {
+        status: 303,
+        headers: response.headers,
+      })
+    }
+
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Unable to open table session." },
+      {
+        status: 400,
+        headers: response.headers,
+      },
+    )
+  }
+}

--- a/app/api/member/wallet/test-topup/route.ts
+++ b/app/api/member/wallet/test-topup/route.ts
@@ -1,0 +1,77 @@
+import { cookies } from "next/headers"
+import { NextResponse } from "next/server"
+
+import { applyTestWalletTopUp, isSameOriginMutation } from "@/lib/member-data"
+
+export async function POST(request: Request) {
+  if (!isSameOriginMutation(request)) {
+    return NextResponse.json({ error: "Cross-origin mutation rejected." }, { status: 403 })
+  }
+
+  const response = NextResponse.json(
+    { walletEntry: null },
+    {
+      headers: {
+        "cache-control": "private, no-store",
+      },
+    },
+  )
+  const cookieStore = await cookies()
+  const contentType = request.headers.get("content-type") ?? ""
+  const acceptsHtml = request.headers.get("accept")?.includes("text/html") ?? false
+
+  try {
+    const body = contentType.includes("application/json")
+      ? await request.json().catch(() => null)
+      : contentType.includes("form")
+        ? Object.fromEntries((await request.formData()).entries())
+        : null
+    const walletEntry = await applyTestWalletTopUp(cookieStore, response, body)
+
+    if (!walletEntry) {
+      if (acceptsHtml) {
+        return NextResponse.redirect(new URL("/login?next=/member/settings", request.url), {
+          status: 303,
+          headers: response.headers,
+        })
+      }
+
+      return NextResponse.json(
+        { error: "Authentication is required." },
+        {
+          status: 401,
+          headers: response.headers,
+        },
+      )
+    }
+
+    if (acceptsHtml) {
+      return NextResponse.redirect(new URL("/member/settings?walletTopUp=success", request.url), {
+        status: 303,
+        headers: response.headers,
+      })
+    }
+
+    return NextResponse.json(
+      { walletEntry },
+      {
+        headers: response.headers,
+      },
+    )
+  } catch (error) {
+    if (acceptsHtml) {
+      return NextResponse.redirect(new URL("/member/settings?walletTopUp=error", request.url), {
+        status: 303,
+        headers: response.headers,
+      })
+    }
+
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Unable to top up test wallet." },
+      {
+        status: 400,
+        headers: response.headers,
+      },
+    )
+  }
+}

--- a/app/games/[slug]/page.tsx
+++ b/app/games/[slug]/page.tsx
@@ -8,7 +8,7 @@ import { GameTablePage } from "@/components/game-table-page"
 import { MemberGameFrame } from "@/components/member-game-frame"
 import { RouletteTablePage } from "@/components/roulette-table-page"
 import { getPlayableTable, playableTableEntries } from "@/lib/game-catalog"
-import { readMemberOverview } from "@/lib/member-data"
+import { readActiveTableSession, readMemberOverview } from "@/lib/member-data"
 
 export function generateStaticParams() {
   return playableTableEntries.map((game) => ({ slug: game.slug }))
@@ -32,22 +32,57 @@ export default async function GameRoutePage({
     redirect(`/login?next=${encodeURIComponent(`/games/${slug}`)}`)
   }
 
-  let page = <GameTablePage entry={game} defaultLanguage={member.settings.language} />
+  const initialProgress = member.progress.find((progress) => progress.gameSlug === game.slug) ?? null
+  const initialTableSession = await readActiveTableSession(cookieStore, game.slug)
+  const gameStateProps = {
+    initialWalletBalance: member.wallet.balance,
+    initialProgress,
+  }
+
+  let page = <GameTablePage entry={game} defaultLanguage={member.settings.language} {...gameStateProps} />
 
   if (game.ruleSet === "baccarat") {
-    page = <BaccaratTablePage entry={game} defaultLanguage={member.settings.language} />
+    page = (
+      <BaccaratTablePage
+        entry={game}
+        defaultLanguage={member.settings.language}
+        initialTableSession={initialTableSession}
+        {...gameStateProps}
+      />
+    )
   }
 
   if (game.ruleSet === "blackjack") {
-    page = <BlackjackTablePage entry={game} defaultLanguage={member.settings.language} />
+    page = (
+      <BlackjackTablePage
+        entry={game}
+        defaultLanguage={member.settings.language}
+        initialTableSession={initialTableSession}
+        {...gameStateProps}
+      />
+    )
   }
 
   if (game.ruleSet === "roulette") {
-    page = <RouletteTablePage entry={game} defaultLanguage={member.settings.language} />
+    page = (
+      <RouletteTablePage
+        entry={game}
+        defaultLanguage={member.settings.language}
+        initialTableSession={initialTableSession}
+        {...gameStateProps}
+      />
+    )
   }
 
   if (game.ruleSet === "dice") {
-    page = <DiceTablePage entry={game} defaultLanguage={member.settings.language} />
+    page = (
+      <DiceTablePage
+        entry={game}
+        defaultLanguage={member.settings.language}
+        initialTableSession={initialTableSession}
+        {...gameStateProps}
+      />
+    )
   }
 
   return (

--- a/app/member/settings/page.tsx
+++ b/app/member/settings/page.tsx
@@ -80,7 +80,11 @@ export default async function MemberSettingsPage() {
             <Settings className="h-5 w-5 text-primary" />
             <h2 className="text-lg font-semibold text-foreground">{copy.preferences}</h2>
           </div>
-          <MemberSettingsForm initialSettings={member.settings} />
+          <MemberSettingsForm
+            initialSettings={member.settings}
+            initialWalletBalance={member.wallet.balance}
+            enableTestWalletTopUp={process.env.NODE_ENV !== "production" || process.env.TAIHU_ENABLE_TEST_WALLET_TOPUP === "true"}
+          />
         </ThemePanelSurface>
 
         <aside className="space-y-6">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,6 +16,7 @@ export default async function HomePage() {
     <PlayerHomePage
       initialLanguage={member.settings.language}
       initialMemberName={member.profile.displayName}
+      initialMemberOverview={member}
     />
   )
 }

--- a/components/baccarat-table-page.tsx
+++ b/components/baccarat-table-page.tsx
@@ -14,6 +14,7 @@ import {
 import { useLanguage } from "@/hooks/use-language"
 import { type Language } from "@/lib/home-content"
 import { type CasinoTableEntry } from "@/lib/game-catalog"
+import { type MemberGameProgress, type MemberTableSession } from "@/lib/member-data"
 import { cn } from "@/lib/utils"
 
 type BetKey = "player" | "banker" | "tie" | "playerPair" | "bankerPair"
@@ -42,6 +43,7 @@ interface BaccaratHistory extends BaccaratRound {
   delta: number
   bankroll: number
   totalStake: number
+  bets: BetLedger
   createdAt: string
 }
 
@@ -494,13 +496,14 @@ async function persistServerProgress(
   entry: CasinoTableEntry,
   record: BaccaratHistory,
   language: Language,
+  tableSessionId?: string,
 ) {
   const summary =
     language === "zh"
       ? `${winnerText(record.winner, language)} ${record.playerPoint}:${record.bankerPoint}，本轮 ${formatDelta(record.delta)}`
       : `${winnerText(record.winner, language)} ${record.playerPoint}:${record.bankerPoint}, round ${formatDelta(record.delta)}`
 
-  await fetch("/api/member/progress", {
+  const response = await fetch("/api/member/progress", {
     method: "POST",
     headers: {
       "content-type": "application/json",
@@ -511,25 +514,59 @@ async function persistServerProgress(
       delta: record.delta,
       bankroll: record.bankroll,
       summary,
+      idempotencyKey: record.id,
+      tableSessionId,
+      totalStake: record.totalStake,
+      betSnapshot: {
+        bets: record.bets,
+        totalStake: record.totalStake,
+      },
+      resultSnapshot: {
+        winner: record.winner,
+        playerPoint: record.playerPoint,
+        bankerPoint: record.bankerPoint,
+        playerCards: record.playerCards,
+        bankerCards: record.bankerCards,
+        playerPair: record.playerPair,
+        bankerPair: record.bankerPair,
+      },
     }),
   }).catch(() => null)
+
+  if (!response?.ok) {
+    return null
+  }
+
+  const payload = (await response.json().catch(() => null)) as { progress?: { bankroll?: unknown } } | null
+  return typeof payload?.progress?.bankroll === "number" ? payload.progress.bankroll : null
 }
 
 export function BaccaratTablePage({
   entry,
   defaultLanguage,
+  initialWalletBalance,
+  initialProgress,
+  initialTableSession,
 }: {
   entry: CasinoTableEntry
   defaultLanguage: Language
+  initialWalletBalance: number
+  initialProgress: MemberGameProgress | null
+  initialTableSession: MemberTableSession | null
 }) {
   const [language] = useLanguage(defaultLanguage)
   const isChinese = language === "zh"
   const isVip = Boolean(entry.variantOf)
-  const initialBankroll = isVip ? 5000 : 1000
+  const initialBankroll = initialTableSession?.chipBalance ?? initialProgress?.bankroll ?? 0
   const defaultChips = isVip ? [100, 250, 500, 1000, 2500] : [10, 25, 50, 100, 250]
   const defaultStake = isVip ? 250 : 25
 
   const [bankroll, setBankroll] = useState(initialBankroll)
+  const [walletBalance, setWalletBalance] = useState(initialWalletBalance)
+  const [tableSession, setTableSession] = useState<MemberTableSession | null>(initialTableSession)
+  const [buyInAmount, setBuyInAmount] = useState(isVip ? 500 : 100)
+  const [isOpeningSession, setIsOpeningSession] = useState(false)
+  const [isCashingOut, setIsCashingOut] = useState(false)
   const [stake, setStake] = useState(defaultStake)
   const [chips, setChips] = useState(defaultChips)
   const [initialBankrollInput, setInitialBankrollInput] = useState(String(initialBankroll))
@@ -538,7 +575,18 @@ export function BaccaratTablePage({
   const [shoe, setShoe] = useState<BaccaratCard[]>(() => freshShoe())
   const [lastRound, setLastRound] = useState<BaccaratRound | null>(null)
   const [history, setHistory] = useState<BaccaratHistory[]>([])
-  const [stats, setStats] = useState<BaccaratStats>(initialStats)
+  const [stats, setStats] = useState<BaccaratStats>(() =>
+    initialProgress
+      ? {
+          rounds: initialProgress.plays,
+          hitRounds: initialProgress.wins,
+          totalStake: 0,
+          totalDelta: initialProgress.lastDelta,
+          lastDelta: initialProgress.lastDelta,
+          ties: initialProgress.lastResult === "push" ? 1 : 0,
+        }
+      : initialStats,
+  )
   const [message, setMessage] = useState(
     isChinese
       ? "选择筹码并点击下注区域，准备下一手。"
@@ -568,6 +616,20 @@ export function BaccaratTablePage({
   const displayWinner = dealing ? undefined : lastRound?.winner
 
   useEffect(() => {
+    if (!initialTableSession) {
+      window.localStorage.removeItem(storageKey)
+      setWalletBalance(initialWalletBalance)
+      setTableSession(null)
+      setBankroll(0)
+      setInitialBankrollInput("0")
+      setBets(cloneEmptyBets())
+      setHistory([])
+      setLastRound(null)
+      setVisibleDeal(null)
+      setDealProgress(0)
+      return
+    }
+
     const saved = window.localStorage.getItem(storageKey)
 
     if (!saved) {
@@ -612,7 +674,24 @@ export function BaccaratTablePage({
     } catch {
       window.localStorage.removeItem(storageKey)
     }
-  }, [storageKey])
+
+    const syncedBankroll = initialTableSession?.chipBalance ?? initialProgress?.bankroll ?? 0
+    setWalletBalance(initialWalletBalance)
+    setTableSession(initialTableSession)
+    setBankroll(syncedBankroll)
+    setInitialBankrollInput(String(syncedBankroll))
+
+    if (initialProgress) {
+      setStats({
+        rounds: initialProgress.plays,
+        hitRounds: initialProgress.wins,
+        totalStake: 0,
+        totalDelta: initialProgress.lastDelta,
+        lastDelta: initialProgress.lastDelta,
+        ties: initialProgress.lastResult === "push" ? 1 : 0,
+      })
+    }
+  }, [storageKey, initialProgress, initialWalletBalance, initialTableSession])
 
   function persistLocal(
     nextBankroll: number,
@@ -692,10 +771,105 @@ export function BaccaratTablePage({
     setMessage(isChinese ? "局面已重置，准备重新开靴。" : "Table reset. Ready for a fresh shoe.")
   }
 
+  async function openSession() {
+    const amount = Math.min(1000000, Math.max(1, roundMoney(Number(buyInAmount))))
+
+    if (amount > walletBalance) {
+      setMessage(isChinese ? "钱包余额不足，无法买入这笔筹码。" : "Wallet balance is not enough for this buy-in.")
+      return
+    }
+
+    setIsOpeningSession(true)
+    setMessage(isChinese ? "正在从钱包买入桌台筹码..." : "Buying chips from your wallet...")
+
+    try {
+      const response = await fetch("/api/member/table-sessions", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          gameSlug: entry.slug,
+          buyInAmount: amount,
+          idempotencyKey: `baccarat-buy-in-${entry.slug}-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+        }),
+      })
+      const payload = (await response.json().catch(() => null)) as {
+        error?: string
+        tableSession?: MemberTableSession
+        wallet?: { balance?: unknown }
+      } | null
+
+      if (!response.ok || !payload?.tableSession) {
+        throw new Error(payload?.error ?? "Unable to buy in.")
+      }
+
+      setTableSession(payload.tableSession)
+      setBankroll(payload.tableSession.chipBalance)
+      setInitialBankrollInput(String(payload.tableSession.chipBalance))
+      setWalletBalance(typeof payload.wallet?.balance === "number" ? payload.wallet.balance : walletBalance - amount)
+      setBets(cloneEmptyBets())
+      window.localStorage.removeItem(storageKey)
+      setMessage(isChinese ? "买入成功，桌台筹码已准备好。" : "Buy-in complete. Table chips are ready.")
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : isChinese ? "买入失败。" : "Buy-in failed.")
+    } finally {
+      setIsOpeningSession(false)
+    }
+  }
+
+  async function cashOutSession() {
+    if (!tableSession || isCashingOut || dealing) {
+      return
+    }
+
+    setIsCashingOut(true)
+    setMessage(isChinese ? "正在带走筹码并结算回钱包..." : "Cashing out table chips to your wallet...")
+
+    try {
+      const response = await fetch(`/api/member/table-sessions/${tableSession.id}/cash-out`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          idempotencyKey: `baccarat-cash-out-${tableSession.id}-${Date.now()}`,
+        }),
+      })
+      const payload = (await response.json().catch(() => null)) as {
+        error?: string
+        tableSession?: MemberTableSession
+        wallet?: { balance?: unknown }
+      } | null
+
+      if (!response.ok || !payload?.tableSession) {
+        throw new Error(payload?.error ?? "Unable to cash out.")
+      }
+
+      setTableSession(null)
+      setBankroll(0)
+      setInitialBankrollInput("0")
+      setWalletBalance(typeof payload.wallet?.balance === "number" ? payload.wallet.balance : walletBalance + tableSession.chipBalance)
+      setBets(cloneEmptyBets())
+      window.localStorage.removeItem(storageKey)
+      setMessage(isChinese ? "筹码已带走，余额已回到钱包。" : "Chips cashed out. Balance returned to wallet.")
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : isChinese ? "离桌失败。" : "Cash-out failed.")
+    } finally {
+      setIsCashingOut(false)
+    }
+  }
+
   async function settleRound() {
     if (dealing) {
       return
     }
+
+    if (!tableSession) {
+      setMessage(isChinese ? "请先从钱包买入筹码再入桌。" : "Buy in from your wallet before playing this table.")
+      return
+    }
+    const activeTableSession = tableSession
 
     if (preview.totalStake <= 0) {
       setMessage(isChinese ? "请先在下注区放筹码。" : "Place at least one bet first.")
@@ -764,6 +938,7 @@ export function BaccaratTablePage({
       delta,
       bankroll: nextBankroll,
       totalStake: stakeThisRound,
+      bets: betsThisRound,
       createdAt: new Date().toISOString(),
     }
     const nextHistory = [record, ...history].slice(0, 30)
@@ -788,6 +963,7 @@ export function BaccaratTablePage({
     setShoe(nextShoe)
     setLastRound(round)
     setBankroll(nextBankroll)
+    setTableSession({ ...activeTableSession, chipBalance: nextBankroll })
     setHistory(nextHistory)
     setStats(nextStats)
     setBets(cloneEmptyBets())
@@ -800,7 +976,13 @@ export function BaccaratTablePage({
         : `Result: ${winnerText(round.winner, languageThisRound)}, round ${formatDelta(delta)}.`,
     )
     persistLocal(nextBankroll, nextHistory, nextStats, round)
-    void persistServerProgress(entry, record, languageThisRound)
+    void persistServerProgress(entry, record, languageThisRound, activeTableSession.id).then((serverBankroll) => {
+      if (typeof serverBankroll === "number") {
+        setBankroll(serverBankroll)
+        setTableSession((current) => current ? { ...current, chipBalance: serverBankroll } : current)
+        persistLocal(serverBankroll, nextHistory, nextStats, round)
+      }
+    })
   }
 
   return (
@@ -862,6 +1044,76 @@ export function BaccaratTablePage({
           </div>
         </header>
 
+        {!tableSession ? (
+          <section className="rounded-lg border border-[#d0b06e]/35 bg-black/25 p-5 shadow-[0_18px_50px_rgba(0,0,0,0.28)]">
+            <div className="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
+              <div>
+                <p className="text-sm font-black uppercase tracking-[0.16em] text-[#d0b06e]">
+                  {isChinese ? "买入筹码" : "Table buy-in"}
+                </p>
+                <h2 className="mt-2 text-2xl font-black text-[#fff4d8]">
+                  {isChinese ? "先从钱包买入本桌筹码" : "Buy chips before joining this table"}
+                </h2>
+                <p className="mt-2 max-w-2xl text-sm leading-6 text-[#cbbd91]">
+                  {isChinese
+                    ? "钱包余额不会在每手牌里直接变化；本桌下注只使用桌台筹码，离桌时再带走剩余筹码回钱包。"
+                    : "Your wallet does not change on every hand. Bets use table chips, then cash out remaining chips back to your wallet."}
+                </p>
+                <p className="mt-3 text-sm font-black text-[#f4d18a]">
+                  {isChinese ? "钱包余额" : "Wallet"} {formatMoney(walletBalance)}
+                </p>
+              </div>
+
+              <form
+                action="/api/member/table-sessions"
+                method="post"
+                className="flex flex-col gap-3 sm:flex-row sm:items-end"
+                onSubmit={(event) => {
+                  event.preventDefault()
+                  void openSession()
+                }}
+              >
+                <input type="hidden" name="gameSlug" value={entry.slug} />
+                <div className="space-y-2">
+                  <label htmlFor="baccaratBuyInAmount" className="text-sm font-black text-[#fff4d8]">
+                    {isChinese ? "买入金额" : "Buy-in amount"}
+                  </label>
+                  <input
+                    id="baccaratBuyInAmount"
+                    name="buyInAmount"
+                    type="number"
+                    min={1}
+                    max={1000000}
+                    step={1}
+                    value={buyInAmount}
+                    onChange={(event) => setBuyInAmount(Number(event.target.value))}
+                    className="h-11 w-44 rounded-lg border border-[#d0b06e]/35 bg-black/30 px-3 text-base font-black text-[#fff4d8] outline-none transition focus:border-[#f0cf83]"
+                  />
+                </div>
+                <div className="flex gap-2">
+                  {(isVip ? [500, 1000, 2500] : [100, 250, 500]).map((amount) => (
+                    <button
+                      key={amount}
+                      type="button"
+                      onClick={() => setBuyInAmount(amount)}
+                      className="h-11 rounded-lg border border-[#d0b06e]/30 bg-black/20 px-3 text-sm font-black text-[#fff4d8] transition hover:bg-[#d0b06e]/15"
+                    >
+                      {formatMoney(amount)}
+                    </button>
+                  ))}
+                </div>
+                <button
+                  type="submit"
+                  disabled={isOpeningSession}
+                  className="h-11 rounded-lg bg-[#f0cf83] px-5 text-sm font-black text-[#1c160c] transition hover:bg-[#ffd98c] disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {isOpeningSession ? (isChinese ? "买入中..." : "Buying in...") : isChinese ? "买入并入桌" : "Buy in"}
+                </button>
+              </form>
+            </div>
+          </section>
+        ) : null}
+
         <section className="grid gap-3 lg:grid-cols-[1.16fr_0.84fr]">
           <div className="rounded-lg border border-[#d0b06e]/30 bg-white/[0.035] p-4 shadow-[0_18px_50px_rgba(0,0,0,0.34)] backdrop-blur">
             <div className="mb-4 flex flex-wrap items-start justify-between gap-4">
@@ -869,16 +1121,30 @@ export function BaccaratTablePage({
                 <p className="text-sm font-black uppercase tracking-[0.16em] text-[#d0b06e]">
                   {isChinese ? "资金与发牌" : "Bankroll & Deal"}
                 </p>
-                <p className="mt-3 text-sm text-[#cbbd91]">{isChinese ? "余额" : "Balance"}</p>
+                <p className="mt-3 text-sm text-[#cbbd91]">{isChinese ? "桌台筹码" : "Table chips"}</p>
                 <p className="text-5xl font-black leading-none text-[#f4d18a] md:text-6xl">
                   {formatMoney(bankroll)}
                 </p>
+                <p className="mt-2 text-xs font-bold text-[#cbbd91]">
+                  {isChinese ? "钱包" : "Wallet"} {formatMoney(walletBalance)}
+                </p>
               </div>
+
+              {tableSession ? (
+                <button
+                  type="button"
+                  onClick={cashOutSession}
+                  disabled={dealing || isCashingOut}
+                  className="inline-flex min-h-12 items-center gap-2 rounded-lg border border-[#d0b06e]/35 bg-[#173727] px-4 text-sm font-black text-[#fff4d8] transition hover:bg-[#214a35] disabled:cursor-not-allowed disabled:opacity-55"
+                >
+                  {isCashingOut ? (isChinese ? "离桌中..." : "Cashing out...") : isChinese ? "带走筹码" : "Cash out"}
+                </button>
+              ) : null}
 
               <button
                 type="button"
                 onClick={settleRound}
-                disabled={dealing}
+                disabled={dealing || !tableSession}
                 className="inline-flex min-h-12 items-center gap-2 rounded-lg border border-[#d0b06e]/50 bg-gradient-to-b from-[#f0cf83] to-[#c69d55] px-5 text-base font-black text-[#34240a] shadow-[0_14px_28px_rgba(0,0,0,0.26)] transition hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-55"
               >
                 <Sparkles className="size-5" />

--- a/components/blackjack-table-page.tsx
+++ b/components/blackjack-table-page.tsx
@@ -14,6 +14,8 @@ import {
 import { useLanguage } from "@/hooks/use-language"
 import { type Language } from "@/lib/home-content"
 import { type CasinoTableEntry } from "@/lib/game-catalog"
+import { type MemberGameProgress, type MemberTableSession } from "@/lib/member-data"
+import { cashOutClientTableSession, openClientTableSession } from "@/lib/table-session-client"
 import { cn } from "@/lib/utils"
 
 type Suit = "spades" | "hearts" | "diamonds" | "clubs"
@@ -65,6 +67,22 @@ function initialStats(): BlackjackStats {
     totalDelta: 0,
     lastDelta: 0,
     history: [],
+  }
+}
+
+function statsFromProgress(progress: MemberGameProgress | null): BlackjackStats {
+  const stats = initialStats()
+
+  if (!progress) {
+    return stats
+  }
+
+  return {
+    ...stats,
+    rounds: progress.plays,
+    wins: progress.wins,
+    totalDelta: progress.lastDelta,
+    lastDelta: progress.lastDelta,
   }
 }
 
@@ -353,6 +371,7 @@ function settleHands({
       ...stats.history,
     ].slice(0, 20),
   }
+  const totalStake = totalCommittedStake(hands, insuranceBet)
 
   return {
     balance: nextBalance,
@@ -363,6 +382,7 @@ function settleHands({
         ? `${detail}。本轮 ${formatDelta(roundDelta)}。`
         : `${detail}. Round ${formatDelta(roundDelta)}.`,
     roundDelta,
+    totalStake,
   }
 }
 
@@ -371,8 +391,14 @@ async function persistBlackjackProgress(
   delta: number,
   bankroll: number,
   summary: string,
+  totalStake: number,
+  hands: BlackjackHand[],
+  dealerCards: BlackjackCard[],
+  insuranceBet: number,
+  idempotencyKey: string,
+  tableSessionId?: string,
 ) {
-  await fetch("/api/member/progress", {
+  const response = await fetch("/api/member/progress", {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify({
@@ -381,23 +407,65 @@ async function persistBlackjackProgress(
       delta,
       bankroll,
       summary,
+      idempotencyKey,
+      tableSessionId,
+      totalStake,
+      betSnapshot: {
+        hands: hands.map((hand) => ({
+          label: hand.label,
+          bet: hand.bet,
+          doubled: hand.doubled,
+          fromSplit: hand.fromSplit,
+        })),
+        insuranceBet,
+        totalStake,
+      },
+      resultSnapshot: {
+        dealerCards,
+        hands: hands.map((hand) => ({
+          label: hand.label,
+          cards: hand.cards,
+          resultLabel: hand.resultLabel,
+          busted: hand.busted,
+          naturalBlackjack: hand.naturalBlackjack,
+        })),
+      },
     }),
   }).catch(() => null)
+
+  if (!response?.ok) {
+    return null
+  }
+
+  const payload = (await response.json().catch(() => null)) as { progress?: { bankroll?: unknown } } | null
+  return typeof payload?.progress?.bankroll === "number" ? payload.progress.bankroll : null
 }
 
 export function BlackjackTablePage({
   entry,
   defaultLanguage,
+  initialWalletBalance,
+  initialProgress,
+  initialTableSession,
 }: {
   entry: CasinoTableEntry
   defaultLanguage: Language
+  initialWalletBalance: number
+  initialProgress: MemberGameProgress | null
+  initialTableSession: MemberTableSession | null
 }) {
   const [language] = useLanguage(defaultLanguage)
   const isChinese = language === "zh"
-  const [bankroll, setBankroll] = useState(1000)
+  const initialBankroll = initialTableSession?.chipBalance ?? 0
+  const [bankroll, setBankroll] = useState(initialBankroll)
+  const [walletBalance, setWalletBalance] = useState(initialWalletBalance)
+  const [tableSession, setTableSession] = useState<MemberTableSession | null>(initialTableSession)
+  const [buyInAmount, setBuyInAmount] = useState(100)
+  const [isOpeningSession, setIsOpeningSession] = useState(false)
+  const [isCashingOut, setIsCashingOut] = useState(false)
   const [stake, setStake] = useState(50)
   const [chips, setChips] = useState(defaultChips)
-  const [initialBankrollInput, setInitialBankrollInput] = useState("1000")
+  const [initialBankrollInput, setInitialBankrollInput] = useState(String(initialBankroll))
   const [initialChipsInput, setInitialChipsInput] = useState(defaultChips.join(","))
   const [deck, setDeck] = useState<BlackjackCard[]>(() => freshDeck())
   const [dealerCards, setDealerCards] = useState<BlackjackCard[]>([])
@@ -411,7 +479,7 @@ export function BlackjackTablePage({
       ? "先设置主注，再点击发牌开局。"
       : "Set the main bet, then deal a new hand.",
   )
-  const [stats, setStats] = useState<BlackjackStats>(() => initialStats())
+  const [stats, setStats] = useState<BlackjackStats>(() => statsFromProgress(initialProgress))
   const [showRules, setShowRules] = useState(false)
   const [dealing, setDealing] = useState(false)
   const storageKey = `taihu-blackjack-table-${entry.slug}`
@@ -454,41 +522,65 @@ export function BlackjackTablePage({
   }, [isChinese, phase])
 
   useEffect(() => {
-    const saved = window.localStorage.getItem(storageKey)
+    if (!initialTableSession) {
+      window.localStorage.removeItem(storageKey)
+      setWalletBalance(initialWalletBalance)
+      setTableSession(null)
+      setBankroll(0)
+      setInitialBankrollInput("0")
+      setDealerCards([])
+      setHands([])
+      setActiveHandIndex(0)
+      setPhase("idle")
+      setRevealDealer(true)
+      setInsuranceBet(0)
+      setDealing(false)
 
-    if (!saved) {
+      if (initialProgress) {
+        setStats(statsFromProgress(initialProgress))
+      }
+
       return
     }
 
-    try {
-      const parsed = JSON.parse(saved) as {
-        bankroll?: number
-        stake?: number
-        chips?: number[]
-        stats?: BlackjackStats
-      }
+    const saved = window.localStorage.getItem(storageKey)
 
-      if (typeof parsed.bankroll === "number") {
-        setBankroll(parsed.bankroll)
-        setInitialBankrollInput(String(parsed.bankroll))
-      }
+    if (saved) {
+      try {
+        const parsed = JSON.parse(saved) as {
+          bankroll?: number
+          stake?: number
+          chips?: number[]
+          stats?: BlackjackStats
+        }
 
-      if (typeof parsed.stake === "number") {
-        setStake(parsed.stake)
-      }
+        if (typeof parsed.stake === "number") {
+          setStake(parsed.stake)
+        }
 
-      if (Array.isArray(parsed.chips) && parsed.chips.every((chip) => typeof chip === "number")) {
-        setChips(parsed.chips)
-        setInitialChipsInput(parsed.chips.join(","))
-      }
+        if (Array.isArray(parsed.chips) && parsed.chips.every((chip) => typeof chip === "number")) {
+          setChips(parsed.chips)
+          setInitialChipsInput(parsed.chips.join(","))
+        }
 
-      if (parsed.stats) {
-        setStats(parsed.stats)
+        if (parsed.stats) {
+          setStats(parsed.stats)
+        }
+      } catch {
+        window.localStorage.removeItem(storageKey)
       }
-    } catch {
-      window.localStorage.removeItem(storageKey)
     }
-  }, [storageKey])
+
+    const syncedBankroll = initialTableSession.chipBalance
+    setWalletBalance(initialWalletBalance)
+    setTableSession(initialTableSession)
+    setBankroll(syncedBankroll)
+    setInitialBankrollInput(String(syncedBankroll))
+
+    if (initialProgress) {
+      setStats(statsFromProgress(initialProgress))
+    }
+  }, [storageKey, initialProgress, initialWalletBalance, initialTableSession])
 
   function persistLocal(nextBankroll: number, nextStats: BlackjackStats) {
     window.localStorage.setItem(
@@ -502,6 +594,65 @@ export function BlackjackTablePage({
     )
   }
 
+  async function openSession() {
+    const amount = Math.min(1000000, Math.max(1, Math.round(Number(buyInAmount) * 100) / 100))
+
+    if (amount > walletBalance) {
+      setMessage(isChinese ? "钱包余额不足，无法买入这笔筹码。" : "Wallet balance is not enough for this buy-in.")
+      return
+    }
+
+    setIsOpeningSession(true)
+    setMessage(isChinese ? "正在从钱包买入桌台筹码..." : "Buying chips from your wallet...")
+
+    try {
+      const result = await openClientTableSession(entry.slug, amount, "blackjack-buy-in")
+
+      setTableSession(result.tableSession)
+      setBankroll(result.tableSession.chipBalance)
+      setInitialBankrollInput(String(result.tableSession.chipBalance))
+      setWalletBalance(result.walletBalance ?? walletBalance - amount)
+      setDealerCards([])
+      setHands([])
+      setPhase("idle")
+      setInsuranceBet(0)
+      window.localStorage.removeItem(storageKey)
+      setMessage(isChinese ? "买入成功，桌台筹码已准备好。" : "Buy-in complete. Table chips are ready.")
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : isChinese ? "买入失败。" : "Buy-in failed.")
+    } finally {
+      setIsOpeningSession(false)
+    }
+  }
+
+  async function cashOutSession() {
+    if (!tableSession || isCashingOut || dealing || (phase !== "idle" && phase !== "done")) {
+      return
+    }
+
+    setIsCashingOut(true)
+    setMessage(isChinese ? "正在带走筹码并结算回钱包..." : "Cashing out table chips to your wallet...")
+
+    try {
+      const result = await cashOutClientTableSession(tableSession.id, "blackjack-cash-out")
+
+      setTableSession(null)
+      setBankroll(0)
+      setInitialBankrollInput("0")
+      setWalletBalance(result.walletBalance ?? walletBalance + tableSession.chipBalance)
+      setDealerCards([])
+      setHands([])
+      setPhase("idle")
+      setInsuranceBet(0)
+      window.localStorage.removeItem(storageKey)
+      setMessage(isChinese ? "筹码已带走，余额已回到钱包。" : "Chips cashed out. Balance returned to wallet.")
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : isChinese ? "离桌失败。" : "Cash-out failed.")
+    } finally {
+      setIsCashingOut(false)
+    }
+  }
+
   function finishRound(
     currentBalance: number,
     currentDealer: BlackjackCard[],
@@ -509,6 +660,13 @@ export function BlackjackTablePage({
     currentInsuranceBet: number,
     currentStats: BlackjackStats,
   ) {
+    const activeTableSession = tableSession
+
+    if (!activeTableSession) {
+      setMessage(isChinese ? "请先从钱包买入筹码再入桌。" : "Buy in from your wallet before playing this table.")
+      return
+    }
+
     const settled = settleHands({
       balance: currentBalance,
       dealerCards: currentDealer,
@@ -519,6 +677,7 @@ export function BlackjackTablePage({
     })
 
     setBankroll(settled.balance)
+    setTableSession({ ...activeTableSession, chipBalance: settled.balance })
     setHands(settled.hands)
     setDealerCards(currentDealer)
     setRevealDealer(true)
@@ -527,7 +686,24 @@ export function BlackjackTablePage({
     setPhase("done")
     setMessage(settled.message)
     persistLocal(settled.balance, settled.stats)
-    void persistBlackjackProgress(entry, settled.roundDelta, settled.balance, settled.message)
+    void persistBlackjackProgress(
+      entry,
+      settled.roundDelta,
+      settled.balance,
+      settled.message,
+      settled.totalStake,
+      settled.hands,
+      currentDealer,
+      currentInsuranceBet,
+      `blackjack-${entry.slug}-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+      activeTableSession.id,
+    ).then((serverBankroll) => {
+      if (typeof serverBankroll === "number") {
+        setBankroll(serverBankroll)
+        setTableSession((current) => current ? { ...current, chipBalance: serverBankroll } : current)
+        persistLocal(serverBankroll, settled.stats)
+      }
+    })
   }
 
   function dealerPlay(
@@ -581,6 +757,11 @@ export function BlackjackTablePage({
 
   function deal() {
     if (dealing || (phase !== "idle" && phase !== "done")) {
+      return
+    }
+
+    if (!tableSession) {
+      setMessage(isChinese ? "请先从钱包买入筹码再入桌。" : "Buy in from your wallet before playing this table.")
       return
     }
 
@@ -813,8 +994,10 @@ export function BlackjackTablePage({
   }
 
   function resetTable() {
-    setBankroll(1000)
-    setInitialBankrollInput("1000")
+    const nextBankroll = tableSession?.chipBalance ?? 0
+
+    setBankroll(nextBankroll)
+    setInitialBankrollInput(String(nextBankroll))
     setStake(50)
     setChips(defaultChips)
     setInitialChipsInput(defaultChips.join(","))
@@ -835,7 +1018,7 @@ export function BlackjackTablePage({
       return
     }
 
-    const nextBankroll = clampInt(initialBankrollInput, 1000)
+    const nextBankroll = tableSession?.chipBalance ?? 0
     const nextChips = parseChips(initialChipsInput, defaultChips)
 
     setBankroll(nextBankroll)
@@ -931,6 +1114,76 @@ export function BlackjackTablePage({
           </div>
         </header>
 
+        {!tableSession ? (
+          <section className="rounded-lg border border-[#d0b06e]/35 bg-black/25 p-5 shadow-[0_18px_50px_rgba(0,0,0,0.28)]">
+            <div className="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
+              <div>
+                <p className="text-sm font-black uppercase tracking-[0.16em] text-[#d0b06e]">
+                  {isChinese ? "买入筹码" : "Table buy-in"}
+                </p>
+                <h2 className="mt-2 text-2xl font-black text-[#fff4d8]">
+                  {isChinese ? "先从钱包买入本桌筹码" : "Buy chips before joining this table"}
+                </h2>
+                <p className="mt-2 max-w-2xl text-sm leading-6 text-[#cbbd91]">
+                  {isChinese
+                    ? "本桌下注只使用桌台筹码，离桌时再把剩余筹码带回钱包。"
+                    : "Bets use table chips, then remaining chips return to your wallet when you cash out."}
+                </p>
+                <p className="mt-3 text-sm font-black text-[#f4d18a]">
+                  {isChinese ? "钱包余额" : "Wallet"} {formatMoney(walletBalance)}
+                </p>
+              </div>
+
+              <form
+                action="/api/member/table-sessions"
+                method="post"
+                className="flex flex-col gap-3 sm:flex-row sm:items-end"
+                onSubmit={(event) => {
+                  event.preventDefault()
+                  void openSession()
+                }}
+              >
+                <input type="hidden" name="gameSlug" value={entry.slug} />
+                <div className="space-y-2">
+                  <label htmlFor="blackjackBuyInAmount" className="text-sm font-black text-[#fff4d8]">
+                    {isChinese ? "买入金额" : "Buy-in amount"}
+                  </label>
+                  <input
+                    id="blackjackBuyInAmount"
+                    name="buyInAmount"
+                    type="number"
+                    min={1}
+                    max={1000000}
+                    step={1}
+                    value={buyInAmount}
+                    onChange={(event) => setBuyInAmount(Number(event.target.value))}
+                    className="h-11 w-44 rounded-lg border border-[#d0b06e]/35 bg-black/30 px-3 text-base font-black text-[#fff4d8] outline-none transition focus:border-[#f0cf83]"
+                  />
+                </div>
+                <div className="flex gap-2">
+                  {[100, 250, 500].map((amount) => (
+                    <button
+                      key={amount}
+                      type="button"
+                      onClick={() => setBuyInAmount(amount)}
+                      className="h-11 rounded-lg border border-[#d0b06e]/30 bg-black/20 px-3 text-sm font-black text-[#fff4d8] transition hover:bg-[#d0b06e]/15"
+                    >
+                      {formatMoney(amount)}
+                    </button>
+                  ))}
+                </div>
+                <button
+                  type="submit"
+                  disabled={isOpeningSession}
+                  className="h-11 rounded-lg bg-[#f0cf83] px-5 text-sm font-black text-[#1c160c] transition hover:bg-[#ffd98c] disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {isOpeningSession ? (isChinese ? "买入中..." : "Buying in...") : isChinese ? "买入并入桌" : "Buy in"}
+                </button>
+              </form>
+            </div>
+          </section>
+        ) : null}
+
         <section className="grid gap-3 lg:grid-cols-[1.15fr_0.85fr]">
           <div className="rounded-lg border border-[#d0b06e]/30 bg-white/[0.035] p-4 shadow-[0_18px_50px_rgba(0,0,0,0.34)] backdrop-blur">
             <div className="flex flex-wrap items-start justify-between gap-4">
@@ -938,15 +1191,28 @@ export function BlackjackTablePage({
                 <p className="text-sm font-black uppercase tracking-[0.16em] text-[#d0b06e]">
                   {isChinese ? "资金与操作" : "Bankroll & Actions"}
                 </p>
-                <p className="mt-3 text-sm text-[#cbbd91]">{isChinese ? "余额" : "Balance"}</p>
+                <p className="mt-3 text-sm text-[#cbbd91]">{isChinese ? "桌台筹码" : "Table chips"}</p>
                 <p className="text-5xl font-black leading-none text-[#f4d18a] md:text-6xl">
                   {formatMoney(bankroll)}
                 </p>
+                <p className="mt-2 text-xs font-bold text-[#cbbd91]">
+                  {isChinese ? "钱包" : "Wallet"} {formatMoney(walletBalance)}
+                </p>
               </div>
+              {tableSession ? (
+                <button
+                  type="button"
+                  onClick={cashOutSession}
+                  disabled={isCashingOut || dealing || (phase !== "idle" && phase !== "done")}
+                  className="inline-flex min-h-12 items-center rounded-lg border border-[#d0b06e]/35 bg-[#173727] px-4 text-sm font-black text-[#fff4d8] transition hover:bg-[#214a35] disabled:cursor-not-allowed disabled:opacity-55"
+                >
+                  {isCashingOut ? (isChinese ? "离桌中..." : "Cashing out...") : isChinese ? "带走筹码" : "Cash out"}
+                </button>
+              ) : null}
               <button
                 type="button"
                 onClick={deal}
-                disabled={dealing || (phase !== "idle" && phase !== "done")}
+                disabled={dealing || !tableSession || (phase !== "idle" && phase !== "done")}
                 className="inline-flex min-h-12 items-center rounded-lg border border-[#d0b06e]/50 bg-gradient-to-b from-[#f0cf83] to-[#c69d55] px-5 text-base font-black text-[#34240a] shadow-[0_14px_28px_rgba(0,0,0,0.26)] transition hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-55"
               >
                 {dealing ? (isChinese ? "发牌中" : "Dealing") : isChinese ? "发牌开局" : "Deal"}
@@ -1100,7 +1366,7 @@ export function BlackjackTablePage({
                 min={100}
                 step={100}
                 value={initialBankrollInput}
-                disabled={phase !== "idle" && phase !== "done"}
+                disabled
                 onChange={(event) => setInitialBankrollInput(event.target.value)}
                 className="h-10 w-36 rounded-lg border border-[#d0b06e]/35 bg-black/25 px-3 text-base font-black text-[#fff4d8] outline-none transition focus:border-[#f0cf83] disabled:opacity-50"
               />

--- a/components/dice-table-page.tsx
+++ b/components/dice-table-page.tsx
@@ -7,6 +7,8 @@ import { ArrowLeft, BookOpen, RotateCcw, Settings, Trash2 } from "lucide-react"
 import { useLanguage } from "@/hooks/use-language"
 import { type Language } from "@/lib/home-content"
 import { type CasinoTableEntry } from "@/lib/game-catalog"
+import { type MemberGameProgress, type MemberTableSession } from "@/lib/member-data"
+import { cashOutClientTableSession, openClientTableSession } from "@/lib/table-session-client"
 import { cn } from "@/lib/utils"
 
 type DiceBetKey = "big" | "small" | "odd" | "even" | "triple"
@@ -22,6 +24,8 @@ interface DiceHistory extends DiceOutcome {
   id: string
   round: number
   delta: number
+  totalStake: number
+  bets: DiceBetLedger
   detail: string
 }
 
@@ -216,8 +220,9 @@ async function persistDiceProgress(
   entry: CasinoTableEntry,
   record: DiceHistory,
   bankroll: number,
+  tableSessionId?: string,
 ) {
-  await fetch("/api/member/progress", {
+  const response = await fetch("/api/member/progress", {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify({
@@ -226,24 +231,55 @@ async function persistDiceProgress(
       delta: record.delta,
       bankroll,
       summary: `${record.dice.join("+")}=${record.sum}; ${formatDelta(record.delta)}`,
+      idempotencyKey: record.id,
+      tableSessionId,
+      totalStake: record.totalStake,
+      betSnapshot: {
+        bets: record.bets,
+        totalStake: record.totalStake,
+      },
+      resultSnapshot: {
+        dice: record.dice,
+        sum: record.sum,
+        triple: record.triple,
+      },
     }),
   }).catch(() => null)
+
+  if (!response?.ok) {
+    return null
+  }
+
+  const payload = (await response.json().catch(() => null)) as { progress?: { bankroll?: unknown } } | null
+  return typeof payload?.progress?.bankroll === "number" ? payload.progress.bankroll : null
 }
 
 export function DiceTablePage({
   entry,
   defaultLanguage,
+  initialWalletBalance,
+  initialProgress,
+  initialTableSession,
 }: {
   entry: CasinoTableEntry
   defaultLanguage: Language
+  initialWalletBalance: number
+  initialProgress: MemberGameProgress | null
+  initialTableSession: MemberTableSession | null
 }) {
   const [language] = useLanguage(defaultLanguage)
   const isChinese = language === "zh"
   const defaultChips = [10, 25, 50, 100, 250]
-  const [bankroll, setBankroll] = useState(1000)
+  const initialBankroll = initialTableSession?.chipBalance ?? 0
+  const [bankroll, setBankroll] = useState(initialBankroll)
+  const [walletBalance, setWalletBalance] = useState(initialWalletBalance)
+  const [tableSession, setTableSession] = useState<MemberTableSession | null>(initialTableSession)
+  const [buyInAmount, setBuyInAmount] = useState(100)
+  const [isOpeningSession, setIsOpeningSession] = useState(false)
+  const [isCashingOut, setIsCashingOut] = useState(false)
   const [stake, setStake] = useState(50)
   const [chips, setChips] = useState(defaultChips)
-  const [initialBankrollInput, setInitialBankrollInput] = useState("1000")
+  const [initialBankrollInput, setInitialBankrollInput] = useState(String(initialBankroll))
   const [initialChipsInput, setInitialChipsInput] = useState(defaultChips.join(","))
   const [bets, setBets] = useState<DiceBetLedger>(() => cloneEmptyDiceBets())
   const [dice, setDice] = useState<[number, number, number]>([1, 1, 1])
@@ -255,64 +291,93 @@ export function DiceTablePage({
       : "Click a betting card to add the current stake. Multiple bets can resolve together.",
   )
   const [rolling, setRolling] = useState(false)
-  const [stats, setStats] = useState<DiceStats>({
-    rounds: 0,
+  const [stats, setStats] = useState<DiceStats>(() => ({
+    rounds: initialProgress?.plays ?? 0,
     totalStake: 0,
-    totalDelta: 0,
-    lastDelta: 0,
+    totalDelta: initialProgress?.lastDelta ?? 0,
+    lastDelta: initialProgress?.lastDelta ?? 0,
     history: [],
-  })
+  }))
   const [showRules, setShowRules] = useState(false)
   const storageKey = `taihu-dice-table-${entry.slug}`
   const preview = useMemo(() => calculateDicePreview(bets), [bets])
   const roi = stats.totalStake > 0 ? (stats.totalDelta / stats.totalStake) * 100 : 0
 
   useEffect(() => {
-    const saved = window.localStorage.getItem(storageKey)
+    if (!initialTableSession) {
+      window.localStorage.removeItem(storageKey)
+      setWalletBalance(initialWalletBalance)
+      setTableSession(null)
+      setBankroll(0)
+      setInitialBankrollInput("0")
+      setBets(cloneEmptyDiceBets())
+      setRolling(false)
 
-    if (!saved) {
+      if (initialProgress) {
+        setStats((current) => ({
+          ...current,
+          rounds: initialProgress.plays,
+          totalDelta: initialProgress.lastDelta,
+          lastDelta: initialProgress.lastDelta,
+        }))
+      }
+
       return
     }
 
-    try {
-      const parsed = JSON.parse(saved) as {
-        bankroll?: number
-        stake?: number
-        chips?: number[]
-        stats?: DiceStats
-        dice?: [number, number, number]
-        lastSum?: number
-      }
+    const saved = window.localStorage.getItem(storageKey)
 
-      if (typeof parsed.bankroll === "number") {
-        setBankroll(parsed.bankroll)
-        setInitialBankrollInput(String(parsed.bankroll))
-      }
+    if (saved) {
+      try {
+        const parsed = JSON.parse(saved) as {
+          bankroll?: number
+          stake?: number
+          chips?: number[]
+          stats?: DiceStats
+          dice?: [number, number, number]
+          lastSum?: number
+        }
 
-      if (typeof parsed.stake === "number") {
-        setStake(parsed.stake)
-      }
+        if (typeof parsed.stake === "number") {
+          setStake(parsed.stake)
+        }
 
-      if (Array.isArray(parsed.chips) && parsed.chips.every((chip) => typeof chip === "number")) {
-        setChips(parsed.chips)
-        setInitialChipsInput(parsed.chips.join(","))
-      }
+        if (Array.isArray(parsed.chips) && parsed.chips.every((chip) => typeof chip === "number")) {
+          setChips(parsed.chips)
+          setInitialChipsInput(parsed.chips.join(","))
+        }
 
-      if (parsed.stats) {
-        setStats(parsed.stats)
-      }
+        if (parsed.stats) {
+          setStats(parsed.stats)
+        }
 
-      if (Array.isArray(parsed.dice) && parsed.dice.length === 3) {
-        setDice(parsed.dice)
-      }
+        if (Array.isArray(parsed.dice) && parsed.dice.length === 3) {
+          setDice(parsed.dice)
+        }
 
-      if (typeof parsed.lastSum === "number") {
-        setLastSum(parsed.lastSum)
+        if (typeof parsed.lastSum === "number") {
+          setLastSum(parsed.lastSum)
+        }
+      } catch {
+        window.localStorage.removeItem(storageKey)
       }
-    } catch {
-      window.localStorage.removeItem(storageKey)
     }
-  }, [storageKey])
+
+    const syncedBankroll = initialTableSession.chipBalance
+    setWalletBalance(initialWalletBalance)
+    setTableSession(initialTableSession)
+    setBankroll(syncedBankroll)
+    setInitialBankrollInput(String(syncedBankroll))
+
+    if (initialProgress) {
+      setStats((current) => ({
+        ...current,
+        rounds: initialProgress.plays,
+        totalDelta: initialProgress.lastDelta,
+        lastDelta: initialProgress.lastDelta,
+      }))
+    }
+  }, [storageKey, initialProgress, initialWalletBalance, initialTableSession])
 
   function persistLocal(nextBankroll: number, nextStats: DiceStats, nextDice: [number, number, number], nextSum: number) {
     window.localStorage.setItem(
@@ -328,7 +393,73 @@ export function DiceTablePage({
     )
   }
 
+  async function openSession() {
+    const amount = Math.min(1000000, Math.max(1, Math.round(Number(buyInAmount) * 100) / 100))
+
+    if (amount > walletBalance) {
+      setHeadline(isChinese ? "钱包余额不足" : "Insufficient wallet balance")
+      setSubText(isChinese ? "无法买入这笔筹码。" : "Wallet balance is not enough for this buy-in.")
+      return
+    }
+
+    setIsOpeningSession(true)
+    setHeadline(isChinese ? "买入中..." : "Buying in...")
+    setSubText(isChinese ? "正在从钱包买入桌台筹码。" : "Buying chips from your wallet.")
+
+    try {
+      const result = await openClientTableSession(entry.slug, amount, "dice-buy-in")
+
+      setTableSession(result.tableSession)
+      setBankroll(result.tableSession.chipBalance)
+      setInitialBankrollInput(String(result.tableSession.chipBalance))
+      setWalletBalance(result.walletBalance ?? walletBalance - amount)
+      setBets(cloneEmptyDiceBets())
+      window.localStorage.removeItem(storageKey)
+      setHeadline(isChinese ? "买入成功" : "Buy-in complete")
+      setSubText(isChinese ? "桌台筹码已准备好。" : "Table chips are ready.")
+    } catch (error) {
+      setHeadline(isChinese ? "买入失败" : "Buy-in failed")
+      setSubText(error instanceof Error ? error.message : isChinese ? "请稍后重试。" : "Please try again.")
+    } finally {
+      setIsOpeningSession(false)
+    }
+  }
+
+  async function cashOutSession() {
+    if (!tableSession || isCashingOut || rolling) {
+      return
+    }
+
+    setIsCashingOut(true)
+    setHeadline(isChinese ? "离桌中..." : "Cashing out...")
+    setSubText(isChinese ? "正在带走筹码并结算回钱包。" : "Cashing out table chips to your wallet.")
+
+    try {
+      const result = await cashOutClientTableSession(tableSession.id, "dice-cash-out")
+
+      setTableSession(null)
+      setBankroll(0)
+      setInitialBankrollInput("0")
+      setWalletBalance(result.walletBalance ?? walletBalance + tableSession.chipBalance)
+      setBets(cloneEmptyDiceBets())
+      window.localStorage.removeItem(storageKey)
+      setHeadline(isChinese ? "筹码已带走" : "Chips cashed out")
+      setSubText(isChinese ? "余额已回到钱包。" : "Balance returned to wallet.")
+    } catch (error) {
+      setHeadline(isChinese ? "离桌失败" : "Cash-out failed")
+      setSubText(error instanceof Error ? error.message : isChinese ? "请稍后重试。" : "Please try again.")
+    } finally {
+      setIsCashingOut(false)
+    }
+  }
+
   function addBet(key: DiceBetKey) {
+    if (!tableSession) {
+      setHeadline(isChinese ? "请先买入筹码" : "Buy in first")
+      setSubText(isChinese ? "先从钱包买入桌台筹码再入桌。" : "Buy in from your wallet before playing this table.")
+      return
+    }
+
     const amount = clampInt(stake, 1)
 
     if (preview.totalStake + amount > bankroll) {
@@ -355,7 +486,7 @@ export function DiceTablePage({
   }
 
   function applyInitialSettings() {
-    const nextBankroll = clampInt(initialBankrollInput, 1000)
+    const nextBankroll = tableSession?.chipBalance ?? 0
     const nextChips = parseChips(initialChipsInput, defaultChips)
 
     setBankroll(nextBankroll)
@@ -371,8 +502,10 @@ export function DiceTablePage({
   }
 
   function resetTable() {
-    setBankroll(1000)
-    setInitialBankrollInput("1000")
+    const nextBankroll = tableSession?.chipBalance ?? 0
+
+    setBankroll(nextBankroll)
+    setInitialBankrollInput(String(nextBankroll))
     setChips(defaultChips)
     setInitialChipsInput(defaultChips.join(","))
     setStake(50)
@@ -389,6 +522,13 @@ export function DiceTablePage({
     if (rolling) {
       return
     }
+
+    if (!tableSession) {
+      setHeadline(isChinese ? "请先买入筹码" : "Buy in first")
+      setSubText(isChinese ? "先从钱包买入桌台筹码再入桌。" : "Buy in from your wallet before playing this table.")
+      return
+    }
+    const activeTableSession = tableSession
 
     if (preview.totalStake <= 0) {
       setHeadline(isChinese ? "请先下注" : "Place a bet first")
@@ -425,6 +565,8 @@ export function DiceTablePage({
         sum: result.sum,
         triple: result.triple,
         delta: result.delta,
+        totalStake: preview.totalStake,
+        bets,
         detail: result.detail,
       }
       const nextStats: DiceStats = {
@@ -438,12 +580,19 @@ export function DiceTablePage({
       setDice(actualDice)
       setLastSum(result.sum)
       setBankroll(nextBankroll)
+      setTableSession({ ...activeTableSession, chipBalance: nextBankroll })
       setStats(nextStats)
       setRolling(false)
       setHeadline(result.triple ? (isChinese ? "豹子出现！" : "Triple!") : isChinese ? `和值 ${result.sum}` : `Total ${result.sum}`)
       setSubText(`${result.dice.join(" + ")} = ${result.sum}，${result.detail}。`)
       persistLocal(nextBankroll, nextStats, actualDice, result.sum)
-      void persistDiceProgress(entry, record, nextBankroll)
+      void persistDiceProgress(entry, record, nextBankroll, activeTableSession.id).then((serverBankroll) => {
+        if (typeof serverBankroll === "number") {
+          setBankroll(serverBankroll)
+          setTableSession((current) => current ? { ...current, chipBalance: serverBankroll } : current)
+          persistLocal(serverBankroll, nextStats, actualDice, result.sum)
+        }
+      })
     }, 1400)
   }
 
@@ -504,6 +653,76 @@ export function DiceTablePage({
           </div>
         </header>
 
+        {!tableSession ? (
+          <section className="rounded-lg border border-[#d0b06e]/35 bg-black/25 p-5 shadow-[0_18px_50px_rgba(0,0,0,0.28)]">
+            <div className="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
+              <div>
+                <p className="text-sm font-black uppercase tracking-[0.16em] text-[#d0b06e]">
+                  {isChinese ? "买入筹码" : "Table buy-in"}
+                </p>
+                <h2 className="mt-2 text-2xl font-black text-[#fff4d8]">
+                  {isChinese ? "先从钱包买入本桌筹码" : "Buy chips before joining this table"}
+                </h2>
+                <p className="mt-2 max-w-2xl text-sm leading-6 text-[#cbbd91]">
+                  {isChinese
+                    ? "骰子下注只使用桌台筹码，离桌时再把剩余筹码带回钱包。"
+                    : "Dice bets use table chips, then remaining chips return to your wallet when you cash out."}
+                </p>
+                <p className="mt-3 text-sm font-black text-[#f4d18a]">
+                  {isChinese ? "钱包余额" : "Wallet"} {formatMoney(walletBalance)}
+                </p>
+              </div>
+
+              <form
+                action="/api/member/table-sessions"
+                method="post"
+                className="flex flex-col gap-3 sm:flex-row sm:items-end"
+                onSubmit={(event) => {
+                  event.preventDefault()
+                  void openSession()
+                }}
+              >
+                <input type="hidden" name="gameSlug" value={entry.slug} />
+                <div className="space-y-2">
+                  <label htmlFor="diceBuyInAmount" className="text-sm font-black text-[#fff4d8]">
+                    {isChinese ? "买入金额" : "Buy-in amount"}
+                  </label>
+                  <input
+                    id="diceBuyInAmount"
+                    name="buyInAmount"
+                    type="number"
+                    min={1}
+                    max={1000000}
+                    step={1}
+                    value={buyInAmount}
+                    onChange={(event) => setBuyInAmount(Number(event.target.value))}
+                    className="h-11 w-44 rounded-lg border border-[#d0b06e]/35 bg-black/30 px-3 text-base font-black text-[#fff4d8] outline-none transition focus:border-[#f0cf83]"
+                  />
+                </div>
+                <div className="flex gap-2">
+                  {[100, 250, 500].map((amount) => (
+                    <button
+                      key={amount}
+                      type="button"
+                      onClick={() => setBuyInAmount(amount)}
+                      className="h-11 rounded-lg border border-[#d0b06e]/30 bg-black/20 px-3 text-sm font-black text-[#fff4d8] transition hover:bg-[#d0b06e]/15"
+                    >
+                      {formatMoney(amount)}
+                    </button>
+                  ))}
+                </div>
+                <button
+                  type="submit"
+                  disabled={isOpeningSession}
+                  className="h-11 rounded-lg bg-[#f0cf83] px-5 text-sm font-black text-[#1c160c] transition hover:bg-[#ffd98c] disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {isOpeningSession ? (isChinese ? "买入中..." : "Buying in...") : isChinese ? "买入并入桌" : "Buy in"}
+                </button>
+              </form>
+            </div>
+          </section>
+        ) : null}
+
         <section className="grid gap-3 lg:grid-cols-[1.15fr_0.85fr]">
           <div className="rounded-lg border border-[#d0b06e]/30 bg-white/[0.035] p-4 shadow-[0_18px_50px_rgba(0,0,0,0.34)] backdrop-blur">
             <div className="flex flex-wrap items-start justify-between gap-4">
@@ -511,15 +730,28 @@ export function DiceTablePage({
                 <p className="text-sm font-black uppercase tracking-[0.16em] text-[#d0b06e]">
                   {isChinese ? "资金与掷骰" : "Bankroll & Roll"}
                 </p>
-                <p className="mt-3 text-sm text-[#cbbd91]">{isChinese ? "玩家余额" : "Balance"}</p>
+                <p className="mt-3 text-sm text-[#cbbd91]">{isChinese ? "桌台筹码" : "Table chips"}</p>
                 <p className="text-5xl font-black leading-none text-[#f4d18a] md:text-6xl">
                   {formatMoney(bankroll)}
                 </p>
+                <p className="mt-2 text-xs font-bold text-[#cbbd91]">
+                  {isChinese ? "钱包" : "Wallet"} {formatMoney(walletBalance)}
+                </p>
               </div>
+              {tableSession ? (
+                <button
+                  type="button"
+                  onClick={cashOutSession}
+                  disabled={rolling || isCashingOut}
+                  className="inline-flex min-h-12 items-center rounded-lg border border-[#d0b06e]/35 bg-[#173727] px-4 text-sm font-black text-[#fff4d8] transition hover:bg-[#214a35] disabled:cursor-not-allowed disabled:opacity-55"
+                >
+                  {isCashingOut ? (isChinese ? "离桌中..." : "Cashing out...") : isChinese ? "带走筹码" : "Cash out"}
+                </button>
+              ) : null}
               <button
                 type="button"
                 onClick={roll}
-                disabled={rolling || preview.totalStake <= 0 || bankroll < preview.totalStake}
+                disabled={rolling || !tableSession || preview.totalStake <= 0 || bankroll < preview.totalStake}
                 className="inline-flex min-h-12 items-center rounded-lg border border-[#d0b06e]/50 bg-gradient-to-b from-[#f0cf83] to-[#c69d55] px-5 text-base font-black text-[#34240a] shadow-[0_14px_28px_rgba(0,0,0,0.26)] transition hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-55"
               >
                 {rolling ? (isChinese ? "掷骰中" : "Rolling") : isChinese ? "掷骰结算" : "Roll"}
@@ -635,6 +867,7 @@ export function DiceTablePage({
                 min={100}
                 step={100}
                 value={initialBankrollInput}
+                disabled
                 onChange={(event) => setInitialBankrollInput(event.target.value)}
                 className="h-10 w-36 rounded-lg border border-[#d0b06e]/35 bg-black/25 px-3 text-base font-black text-[#fff4d8] outline-none transition focus:border-[#f0cf83]"
               />

--- a/components/game-table-page.tsx
+++ b/components/game-table-page.tsx
@@ -16,6 +16,7 @@ import { Button } from "@/components/ui/button"
 import { useLanguage } from "@/hooks/use-language"
 import { type Language } from "@/lib/home-content"
 import { playableTableEntries, type CasinoTableEntry } from "@/lib/game-catalog"
+import { type MemberGameProgress } from "@/lib/member-data"
 import { cn } from "@/lib/utils"
 
 type Outcome = "win" | "loss" | "push"
@@ -157,15 +158,28 @@ function nextStats(current: GameStats, outcome: Outcome): GameStats {
 export function GameTablePage({
   entry,
   defaultLanguage,
+  initialWalletBalance,
+  initialProgress,
 }: {
   entry: CasinoTableEntry
   defaultLanguage: Language
+  initialWalletBalance: number
+  initialProgress: MemberGameProgress | null
 }) {
   const [language] = useLanguage(defaultLanguage)
-  const [bankroll, setBankroll] = useState(25000)
+  const [bankroll, setBankroll] = useState(initialProgress?.bankroll ?? initialWalletBalance)
   const [bet, setBet] = useState(entry.defaultBet)
   const [history, setHistory] = useState<RoundRecord[]>([])
-  const [stats, setStats] = useState<GameStats>(initialStats)
+  const [stats, setStats] = useState<GameStats>(() =>
+    initialProgress
+      ? {
+          plays: initialProgress.plays,
+          wins: initialProgress.wins,
+          losses: initialProgress.losses,
+          streak: initialProgress.streak,
+        }
+      : initialStats,
+  )
   const [statusText, setStatusText] = useState("请选择筹码和下注区域，准备下一手。")
   const [baccaratPick, setBaccaratPick] = useState<BaccaratPick>("banker")
   const [roulettePick, setRoulettePick] = useState<RoulettePick>("red")
@@ -213,7 +227,18 @@ export function GameTablePage({
       }
     }
 
-  }, [entry.slug])
+    const syncedBankroll = initialProgress?.bankroll ?? initialWalletBalance
+    setBankroll(syncedBankroll)
+
+    if (initialProgress) {
+      setStats({
+        plays: initialProgress.plays,
+        wins: initialProgress.wins,
+        losses: initialProgress.losses,
+        streak: initialProgress.streak,
+      })
+    }
+  }, [entry.slug, initialProgress, initialWalletBalance])
 
   function persistLocal(nextBankroll: number, nextHistory: RoundRecord[], nextStatsValue: GameStats) {
     window.localStorage.setItem(
@@ -227,7 +252,7 @@ export function GameTablePage({
   }
 
   async function persistServer(record: RoundRecord) {
-    await fetch("/api/member/progress", {
+    const response = await fetch("/api/member/progress", {
       method: "POST",
       headers: {
         "content-type": "application/json",
@@ -238,8 +263,25 @@ export function GameTablePage({
         delta: record.delta,
         bankroll: record.bankroll,
         summary: record.detail,
+        idempotencyKey: record.id,
+        totalStake: bet,
+        betSnapshot: {
+          stake: bet,
+          ruleSet: entry.ruleSet,
+        },
+        resultSnapshot: {
+          label: record.label,
+          detail: record.detail,
+        },
       }),
     }).catch(() => null)
+
+    if (!response?.ok) {
+      return null
+    }
+
+    const payload = (await response.json().catch(() => null)) as { progress?: { bankroll?: unknown } } | null
+    return typeof payload?.progress?.bankroll === "number" ? payload.progress.bankroll : null
   }
 
   function commitRecord(record: RoundRecord) {
@@ -252,7 +294,12 @@ export function GameTablePage({
     setStatusText(record.detail)
     persistLocal(record.bankroll, nextHistory, nextStatsValue)
 
-    void persistServer(record)
+    void persistServer(record).then((serverBankroll) => {
+      if (typeof serverBankroll === "number") {
+        setBankroll(serverBankroll)
+        persistLocal(serverBankroll, nextHistory, nextStatsValue)
+      }
+    })
   }
 
   function settleBaccarat() {

--- a/components/live-players.tsx
+++ b/components/live-players.tsx
@@ -1,69 +1,67 @@
 "use client"
 
-import { useEffect, useState } from "react"
-import { Circle } from "lucide-react"
+import { BarChart3 } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 import type { HomeLiveItem } from "@/lib/home-content"
-import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar"
+import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 
 export function LivePlayers({
   title,
   liveLabel,
+  emptyLabel,
   players,
   className,
 }: {
   title: string
   liveLabel: string
+  emptyLabel: string
   players: HomeLiveItem[]
   className?: string
 }) {
-  const [currentIndex, setCurrentIndex] = useState(0)
-
-  useEffect(() => {
-    if (players.length === 0) {
-      return
-    }
-
-    const interval = setInterval(() => {
-      setCurrentIndex((prev) => (prev + 1) % players.length)
-    }, 3000)
-
-    return () => clearInterval(interval)
-  }, [players])
-
   return (
     <div className={cn("rounded-2xl border border-border/50 bg-card p-5", className)}>
       <div className="mb-4 flex items-center justify-between">
         <h3 className="text-sm font-medium text-foreground">{title}</h3>
         <div className="flex items-center gap-1.5 text-xs text-primary">
-          <Circle className="h-2 w-2 fill-primary animate-pulse" />
+          <BarChart3 className="h-3.5 w-3.5" />
           <span>{liveLabel}</span>
         </div>
       </div>
 
       <div className="space-y-3">
-        {players.map((player, index) => (
-          <div
-            key={player.name}
-            className={cn(
-              "flex items-center gap-3 rounded-xl p-2 transition-all duration-500",
-              index === currentIndex && "bg-primary/10",
-            )}
-          >
-            <Avatar className="h-8 w-8">
-              {player.avatar ? <AvatarImage src={player.avatar} alt={player.name} /> : null}
-              <AvatarFallback className="bg-secondary text-xs text-foreground">
-                {player.name.split(" ").map((n) => n[0]).join("")}
-              </AvatarFallback>
-            </Avatar>
-            <div className="min-w-0 flex-1">
-              <p className="truncate text-sm font-medium text-foreground">{player.name}</p>
-              <p className="text-xs text-muted-foreground">{player.game}</p>
-            </div>
-            <span className="text-sm font-semibold text-primary">{player.amount}</span>
+        {players.length > 0 ? (
+          players.map((player, index) => {
+            const isLoss = player.amount.startsWith("-")
+
+            return (
+              <div
+                key={player.name}
+                className={cn(
+                  "flex items-center gap-3 rounded-xl p-2 transition-colors",
+                  index === 0 && "bg-primary/10",
+                )}
+              >
+                <Avatar className="h-8 w-8">
+                  <AvatarFallback className="bg-secondary text-xs font-semibold text-foreground">
+                    {index + 1}
+                  </AvatarFallback>
+                </Avatar>
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-sm font-medium text-foreground">{player.name}</p>
+                  <p className="text-xs text-muted-foreground">{player.game}</p>
+                </div>
+                <span className={cn("text-sm font-semibold", isLoss ? "text-destructive" : "text-primary")}>
+                  {player.amount}
+                </span>
+              </div>
+            )
+          })
+        ) : (
+          <div className="rounded-xl border border-dashed border-border/70 p-4 text-sm text-muted-foreground">
+            {emptyLabel}
           </div>
-        ))}
+        )}
       </div>
     </div>
   )

--- a/components/member-settings-form.tsx
+++ b/components/member-settings-form.tsx
@@ -1,10 +1,11 @@
 "use client"
 
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useRef, useState, type FormEvent } from "react"
 import { useTheme } from "next-themes"
 import { useRouter } from "next/navigation"
 import { CheckCircle2, Loader2 } from "lucide-react"
 
+import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import {
@@ -12,7 +13,6 @@ import {
   SelectContent,
   SelectItem,
   SelectTrigger,
-  SelectValue,
 } from "@/components/ui/select"
 import { Switch } from "@/components/ui/switch"
 import { LANGUAGE_STORAGE_KEY } from "@/lib/home-content"
@@ -53,6 +53,16 @@ function getFormCopy(language: MemberLanguage) {
     saving: isChinese ? "正在自动保存..." : "Auto-saving...",
     saved: isChinese ? "设置已自动保存，并已在会员站点生效。" : "Settings auto-saved and now apply across the member site.",
     saveError: isChinese ? "无法保存设置。" : "Unable to save settings.",
+    testWallet: isChinese ? "测试钱包" : "Test wallet",
+    testWalletDescription: isChinese
+      ? "仅用于本地和测试环境，充值会写入真实钱包流水。"
+      : "Local and test environments only. Top-ups are written to the real wallet ledger.",
+    testWalletBalance: isChinese ? "当前余额" : "Current balance",
+    testWalletAmount: isChinese ? "充值金额" : "Top-up amount",
+    testWalletAction: isChinese ? "充值测试钱包" : "Top up test wallet",
+    testWalletPending: isChinese ? "正在充值..." : "Topping up...",
+    testWalletSuccess: isChinese ? "测试钱包已充值。" : "Test wallet topped up.",
+    testWalletError: isChinese ? "无法充值测试钱包。" : "Unable to top up test wallet.",
     options: {
       dark: isChinese ? "深色" : "Dark",
       light: isChinese ? "浅色" : "Light",
@@ -68,10 +78,29 @@ function getFormCopy(language: MemberLanguage) {
   }
 }
 
-export function MemberSettingsForm({ initialSettings }: { initialSettings: EditableSettings }) {
+function formatMoney(value: number) {
+  return value.toLocaleString("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: value % 1 === 0 ? 0 : 2,
+  })
+}
+
+export function MemberSettingsForm({
+  initialSettings,
+  initialWalletBalance,
+  enableTestWalletTopUp,
+}: {
+  initialSettings: EditableSettings
+  initialWalletBalance: number
+  enableTestWalletTopUp: boolean
+}) {
   const { setTheme } = useTheme()
   const router = useRouter()
   const [settings, setSettings] = useState(initialSettings)
+  const [walletBalance, setWalletBalance] = useState(initialWalletBalance)
+  const [topUpAmount, setTopUpAmount] = useState(1000)
+  const [isToppingUp, setIsToppingUp] = useState(false)
   const [isSaving, setIsSaving] = useState(false)
   const [message, setMessage] = useState(getFormCopy(initialSettings.language).saved)
   const [error, setError] = useState("")
@@ -82,6 +111,10 @@ export function MemberSettingsForm({ initialSettings }: { initialSettings: Edita
     setTheme(initialSettings.theme)
     window.localStorage.setItem(LANGUAGE_STORAGE_KEY, initialSettings.language)
   }, [initialSettings.language, initialSettings.theme, setTheme])
+
+  useEffect(() => {
+    setWalletBalance(initialWalletBalance)
+  }, [initialWalletBalance])
 
   async function persistSettings(nextSettings: EditableSettings) {
     const currentSave = saveSequence.current + 1
@@ -143,6 +176,62 @@ export function MemberSettingsForm({ initialSettings }: { initialSettings: Edita
     updateSetting(key, Number(value) as EditableSettings[typeof key])
   }
 
+  async function topUpTestWallet(event?: FormEvent<HTMLFormElement>) {
+    event?.preventDefault()
+    const amount = Math.min(100000, Math.max(1, Math.round(Number(topUpAmount) * 100) / 100))
+
+    setIsToppingUp(true)
+    setMessage("")
+    setError("")
+
+    try {
+      const response = await fetch("/api/member/wallet/test-topup", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          amount,
+          idempotencyKey: `settings-test-topup-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+        }),
+      })
+      const payload = (await response.json().catch(() => null)) as {
+        error?: string
+        walletEntry?: {
+          balanceAfter?: number
+        }
+      } | null
+
+      if (!response.ok) {
+        throw new Error(payload?.error ?? copy.testWalletError)
+      }
+
+      if (typeof payload?.walletEntry?.balanceAfter === "number") {
+        setWalletBalance(payload.walletEntry.balanceAfter)
+      }
+
+      const memberResponse = await fetch("/api/member/me", {
+        headers: {
+          "cache-control": "no-store",
+        },
+      }).catch(() => null)
+      const memberPayload = memberResponse?.ok
+        ? ((await memberResponse.json().catch(() => null)) as { member?: { wallet?: { balance?: unknown } } } | null)
+        : null
+
+      if (typeof memberPayload?.member?.wallet?.balance === "number") {
+        setWalletBalance(memberPayload.member.wallet.balance)
+      }
+
+      setMessage(copy.testWalletSuccess)
+      router.refresh()
+    } catch (topUpError) {
+      setError(topUpError instanceof Error ? topUpError.message : copy.testWalletError)
+    } finally {
+      setIsToppingUp(false)
+    }
+  }
+
   return (
     <div className="space-y-6">
       <div className="grid gap-4 md:grid-cols-2">
@@ -150,7 +239,7 @@ export function MemberSettingsForm({ initialSettings }: { initialSettings: Edita
           <Label>{copy.theme}</Label>
           <Select value={settings.theme} onValueChange={(value) => updateSetting("theme", value as MemberTheme)}>
             <SelectTrigger className="w-full">
-              <SelectValue placeholder={copy.theme} />
+              <span className="truncate">{copy.options[settings.theme]}</span>
             </SelectTrigger>
             <SelectContent>
               <SelectItem value="dark">{copy.options.dark}</SelectItem>
@@ -164,7 +253,7 @@ export function MemberSettingsForm({ initialSettings }: { initialSettings: Edita
           <Label>{copy.language}</Label>
           <Select value={settings.language} onValueChange={(value) => updateSetting("language", value as MemberLanguage)}>
             <SelectTrigger className="w-full">
-              <SelectValue placeholder={copy.language} />
+              <span className="truncate">{copy.options[settings.language]}</span>
             </SelectTrigger>
             <SelectContent>
               <SelectItem value="zh">{copy.options.zh}</SelectItem>
@@ -180,7 +269,7 @@ export function MemberSettingsForm({ initialSettings }: { initialSettings: Edita
             onValueChange={(value) => updateSetting("profileVisibility", value as ProfileVisibility)}
           >
             <SelectTrigger className="w-full">
-              <SelectValue placeholder={copy.profileVisibility} />
+              <span className="truncate">{copy.options[settings.profileVisibility]}</span>
             </SelectTrigger>
             <SelectContent>
               <SelectItem value="private">{copy.options.private}</SelectItem>
@@ -197,7 +286,7 @@ export function MemberSettingsForm({ initialSettings }: { initialSettings: Edita
             onValueChange={(value) => updateSetting("tableDensity", value as TableDensity)}
           >
             <SelectTrigger className="w-full">
-              <SelectValue placeholder={copy.tableDensity} />
+              <span className="truncate">{copy.options[settings.tableDensity]}</span>
             </SelectTrigger>
             <SelectContent>
               <SelectItem value="comfortable">{copy.options.comfortable}</SelectItem>
@@ -252,13 +341,63 @@ export function MemberSettingsForm({ initialSettings }: { initialSettings: Edita
         />
       </div>
 
+      {enableTestWalletTopUp ? (
+        <div className="rounded-2xl border border-dashed border-primary/40 bg-primary/5 p-4">
+          <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+            <div>
+              <p className="text-sm font-medium text-foreground">{copy.testWallet}</p>
+              <p className="mt-2 text-xs leading-5 text-muted-foreground">{copy.testWalletDescription}</p>
+              <p className="mt-3 text-sm text-foreground">
+                {copy.testWalletBalance} <span className="font-semibold">{formatMoney(walletBalance)}</span>
+              </p>
+            </div>
+            <form
+              action="/api/member/wallet/test-topup"
+              method="post"
+              className="flex flex-col gap-2 sm:flex-row sm:items-end"
+              onSubmit={topUpTestWallet}
+            >
+              <div className="space-y-2">
+                <Label htmlFor="testWalletTopUpAmount">{copy.testWalletAmount}</Label>
+                <Input
+                  id="testWalletTopUpAmount"
+                  name="amount"
+                  type="number"
+                  min={1}
+                  max={100000}
+                  step="0.01"
+                  value={topUpAmount}
+                  onChange={(event) => setTopUpAmount(Number(event.target.value))}
+                />
+              </div>
+              <Button type="submit" disabled={isToppingUp}>
+                {isToppingUp ? (
+                  <>
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                    {copy.testWalletPending}
+                  </>
+                ) : (
+                  copy.testWalletAction
+                )}
+              </Button>
+            </form>
+          </div>
+          {!isToppingUp && message === copy.testWalletSuccess ? (
+            <p className="mt-3 flex items-center gap-2 text-sm text-primary" aria-live="polite">
+              <CheckCircle2 className="h-4 w-4" />
+              {message}
+            </p>
+          ) : null}
+        </div>
+      ) : null}
+
       {isSaving ? (
         <p className="flex items-center gap-2 text-sm text-muted-foreground">
           <Loader2 className="h-4 w-4 animate-spin" />
           {copy.saving}
         </p>
       ) : null}
-      {!isSaving && message ? (
+      {!isSaving && message && message !== copy.testWalletSuccess ? (
         <p className="flex items-center gap-2 text-sm text-primary">
           <CheckCircle2 className="h-4 w-4" />
           {message}

--- a/components/player-home-page.tsx
+++ b/components/player-home-page.tsx
@@ -10,15 +10,14 @@ import { PlayerStats } from "@/components/player-stats"
 import { Button } from "@/components/ui/button"
 import { useLanguage } from "@/hooks/use-language"
 import {
+  type HomeActivityItem,
+  type HomeStatItem,
   type ViewerMode,
   getCoreGame,
   getGameLinks,
   getHomeCopy,
-  getLivePlayers,
   getNavItems,
   getQuickActions,
-  getRecentActivities,
-  getStats,
 } from "@/lib/home-content"
 import { clearMemberSession } from "@/lib/member-session"
 import { playableTableEntries } from "@/lib/game-catalog"
@@ -33,9 +32,271 @@ const gameIcons = {
 interface PlayerHomePageProps {
   initialLanguage: "zh" | "en"
   initialMemberName: string
+  initialMemberOverview: {
+    wallet: {
+      balance: number
+    }
+    progress: Array<{
+      plays: number
+      wins: number
+      losses: number
+      streak: number
+      bestStreak: number
+    }>
+    walletLedger: Array<{
+      id: string
+      amount: number
+      source: string
+      createdAt: string
+      metadata: Record<string, unknown>
+    }>
+    gameRounds: Array<{
+      id: string
+      gameSlug: string
+      outcome: "win" | "loss" | "push"
+      delta: number
+      createdAt: string
+    }>
+  }
 }
 
-export function PlayerHomePage({ initialLanguage, initialMemberName }: PlayerHomePageProps) {
+type RecentActivity = HomeActivityItem & {
+  id: string
+  gameSlug?: string
+}
+
+function formatMoney(value: number) {
+  return value.toLocaleString("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: value % 1 === 0 ? 0 : 2,
+  })
+}
+
+function isToday(value: string) {
+  const date = new Date(value)
+  const today = new Date()
+
+  return (
+    date.getFullYear() === today.getFullYear() &&
+    date.getMonth() === today.getMonth() &&
+    date.getDate() === today.getDate()
+  )
+}
+
+function buildMemberStats(
+  language: "zh" | "en",
+  member: PlayerHomePageProps["initialMemberOverview"],
+): HomeStatItem[] {
+  const plays = member.progress.reduce((sum, progress) => sum + progress.plays, 0)
+  const wins = member.progress.reduce((sum, progress) => sum + progress.wins, 0)
+  const currentStreak = Math.max(0, ...member.progress.map((progress) => progress.streak))
+  const bestStreak = Math.max(0, ...member.progress.map((progress) => progress.bestStreak))
+  const winRate = plays > 0 ? Math.round((wins / plays) * 100) : 0
+  const todayNet = member.gameRounds
+    .filter((round) => isToday(round.createdAt))
+    .reduce((sum, round) => sum + round.delta, 0)
+
+  if (language === "zh") {
+    return [
+      {
+        key: "balance",
+        label: "账户余额",
+        value: formatMoney(member.wallet.balance),
+        subtext: `今日净赢 ${todayNet >= 0 ? "+" : ""}${formatMoney(todayNet)}`,
+        trend: todayNet > 0 ? "up" : todayNet < 0 ? "down" : "neutral",
+      },
+      {
+        key: "rate",
+        label: "胜率",
+        value: `${winRate}%`,
+        subtext: plays > 0 ? `${wins}/${plays} 局获胜` : "还没有完成牌局",
+        trend: winRate >= 50 ? "up" : winRate > 0 ? "neutral" : "neutral",
+      },
+      {
+        key: "recent",
+        label: "最近游玩",
+        value: `${plays} 局`,
+        subtext: member.progress.length > 0 ? `${member.progress.length} 个桌台有记录` : "开始第一局后自动更新",
+        trend: "neutral",
+      },
+      {
+        key: "streak",
+        label: "连胜记录",
+        value: `${currentStreak} 局`,
+        subtext: bestStreak > currentStreak ? `个人最好 ${bestStreak} 局` : "当前为个人最好",
+        trend: currentStreak > 0 ? "up" : "neutral",
+      },
+    ]
+  }
+
+  return [
+    {
+      key: "balance",
+      label: "Balance",
+      value: formatMoney(member.wallet.balance),
+      subtext: `Today ${todayNet >= 0 ? "+" : ""}${formatMoney(todayNet)}`,
+      trend: todayNet > 0 ? "up" : todayNet < 0 ? "down" : "neutral",
+    },
+    {
+      key: "rate",
+      label: "Win Rate",
+      value: `${winRate}%`,
+      subtext: plays > 0 ? `${wins}/${plays} rounds won` : "No settled rounds yet",
+      trend: winRate >= 50 ? "up" : winRate > 0 ? "neutral" : "neutral",
+    },
+    {
+      key: "recent",
+      label: "Recent Play",
+      value: `${plays}`,
+      subtext: member.progress.length > 0 ? `${member.progress.length} tables tracked` : "Updates after your first round",
+      trend: "neutral",
+    },
+    {
+      key: "streak",
+      label: "Streak",
+      value: `${currentStreak}`,
+      subtext: bestStreak > currentStreak ? `Best streak ${bestStreak}` : "Current personal best",
+      trend: currentStreak > 0 ? "up" : "neutral",
+    },
+  ]
+}
+
+function formatSignedMoney(value: number) {
+  if (value === 0) {
+    return "$0"
+  }
+
+  return `${value > 0 ? "+" : "-"}${formatMoney(Math.abs(value))}`
+}
+
+function formatRelativeTime(value: string, language: "zh" | "en") {
+  const timestamp = new Date(value).getTime()
+
+  if (!Number.isFinite(timestamp)) {
+    return language === "zh" ? "刚刚" : "Just now"
+  }
+
+  const elapsedMs = Date.now() - timestamp
+  const elapsedMinutes = Math.max(0, Math.floor(elapsedMs / 60000))
+
+  if (elapsedMinutes < 1) {
+    return language === "zh" ? "刚刚" : "Just now"
+  }
+
+  if (elapsedMinutes < 60) {
+    return language === "zh" ? `${elapsedMinutes} 分钟前` : `${elapsedMinutes} min ago`
+  }
+
+  const elapsedHours = Math.floor(elapsedMinutes / 60)
+
+  if (elapsedHours < 24) {
+    return language === "zh" ? `${elapsedHours} 小时前` : `${elapsedHours} hr ago`
+  }
+
+  const elapsedDays = Math.floor(elapsedHours / 24)
+  return language === "zh" ? `${elapsedDays} 天前` : `${elapsedDays} days ago`
+}
+
+function titleForGameSlug(slug: string | undefined, language: "zh" | "en") {
+  const game = slug ? getCoreGame(slug) : null
+
+  if (!game) {
+    return language === "zh" ? "会员牌局" : "Member Round"
+  }
+
+  return game.title
+}
+
+function resultForLedgerEntry(entry: PlayerHomePageProps["initialMemberOverview"]["walletLedger"][number], language: "zh" | "en") {
+  const outcome = typeof entry.metadata.outcome === "string" ? entry.metadata.outcome : null
+
+  if (outcome === "win" || (!outcome && entry.amount > 0)) {
+    return language === "zh" ? "赢" : "Won"
+  }
+
+  if (outcome === "loss" || (!outcome && entry.amount < 0)) {
+    return language === "zh" ? "负" : "Lost"
+  }
+
+  return language === "zh" ? "和" : "Push"
+}
+
+function resultForGameRound(round: PlayerHomePageProps["initialMemberOverview"]["gameRounds"][number], language: "zh" | "en") {
+  if (round.outcome === "win" || (round.outcome === "push" && round.delta > 0)) {
+    return language === "zh" ? "赢" : "Won"
+  }
+
+  if (round.outcome === "loss" || (round.outcome === "push" && round.delta < 0)) {
+    return language === "zh" ? "负" : "Lost"
+  }
+
+  return language === "zh" ? "和" : "Push"
+}
+
+function buildRecentActivities(
+  language: "zh" | "en",
+  member: PlayerHomePageProps["initialMemberOverview"],
+): RecentActivity[] {
+  return member.gameRounds
+    .slice(0, 4)
+    .map((round) => ({
+      id: round.id,
+      game: titleForGameSlug(round.gameSlug, language),
+      gameSlug: round.gameSlug,
+      result: resultForGameRound(round, language),
+      amount: formatSignedMoney(round.delta),
+      time: formatRelativeTime(round.createdAt, language),
+      positive: round.delta >= 0,
+    }))
+}
+
+function isWithinLastWeek(value: string) {
+  const timestamp = new Date(value).getTime()
+
+  if (!Number.isFinite(timestamp)) {
+    return false
+  }
+
+  return Date.now() - timestamp <= 7 * 24 * 60 * 60 * 1000
+}
+
+function buildWeeklyProfitBoard(
+  language: "zh" | "en",
+  member: PlayerHomePageProps["initialMemberOverview"],
+) {
+  const grouped = new Map<string, { gameSlug?: string; amount: number; rounds: number }>()
+
+  for (const round of member.gameRounds) {
+    if (!isWithinLastWeek(round.createdAt)) {
+      continue
+    }
+
+    const gameSlug = round.gameSlug
+    const key = gameSlug || "unknown"
+    const current = grouped.get(key) ?? { gameSlug, amount: 0, rounds: 0 }
+
+    grouped.set(key, {
+      gameSlug,
+      amount: current.amount + round.delta,
+      rounds: current.rounds + 1,
+    })
+  }
+
+  return Array.from(grouped.values())
+    .sort((left, right) => right.amount - left.amount)
+    .slice(0, 5)
+    .map((item) => ({
+      name: titleForGameSlug(item.gameSlug, language),
+      game:
+        language === "zh"
+          ? `${item.rounds} 局 · 最近 7 天`
+          : `${item.rounds} rounds · Last 7 days`,
+      amount: formatSignedMoney(item.amount),
+    }))
+}
+
+export function PlayerHomePage({ initialLanguage, initialMemberName, initialMemberOverview }: PlayerHomePageProps) {
   const [language] = useLanguage(initialLanguage)
   const isAuthenticated = true
   const authHref = "/login"
@@ -49,10 +310,10 @@ export function PlayerHomePage({ initialLanguage, initialMemberName }: PlayerHom
   const copy = getHomeCopy(language, viewerMode)
   const navItems = getNavItems(language)
   const games = getGameLinks(language)
-  const stats = getStats(language, viewerMode)
+  const stats = buildMemberStats(language, initialMemberOverview)
   const quickActions = getQuickActions(language, viewerMode)
-  const livePlayers = getLivePlayers(language)
-  const recentActivities = getRecentActivities(language, viewerMode)
+  const weeklyProfitBoard = buildWeeklyProfitBoard(language, initialMemberOverview)
+  const recentActivities = buildRecentActivities(language, initialMemberOverview)
   const extraTables = playableTableEntries.filter(
     (table) => table.kind === "game" && !games.some((game) => game.slug === table.slug),
   )
@@ -176,7 +437,8 @@ export function PlayerHomePage({ initialLanguage, initialMemberName }: PlayerHom
                 <LivePlayers
                   title={copy.labels.liveWins}
                   liveLabel={copy.labels.liveBadge}
-                  players={livePlayers}
+                  emptyLabel={language === "zh" ? "本周还没有完成的牌局。" : "No settled rounds this week."}
+                  players={weeklyProfitBoard}
                 />
               </div>
             </aside>
@@ -190,13 +452,13 @@ export function PlayerHomePage({ initialLanguage, initialMemberName }: PlayerHom
               </a>
             </div>
             <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-              {recentActivities.map((activity) => {
-                const matchedGame = games.find((game) => game.title === activity.game)
+              {recentActivities.length > 0 ? recentActivities.map((activity) => {
+                const matchedGame = games.find((game) => game.slug === activity.gameSlug || game.title === activity.game)
                 const fallbackGame = matchedGame ?? getCoreGame("baccarat")!
 
                 return (
                   <Link
-                    key={`${activity.game}-${activity.time}`}
+                    key={activity.id}
                     href={matchedGame ? matchedGame.href : `/games/${fallbackGame.slug}?lang=${language}`}
                     className="lobby-panel-surface rounded-xl border border-border/50 p-4 transition-colors hover:border-primary/20"
                   >
@@ -212,7 +474,11 @@ export function PlayerHomePage({ initialLanguage, initialMemberName }: PlayerHom
                     <p className="mt-1 text-xs text-muted-foreground">{activity.time}</p>
                   </Link>
                 )
-              })}
+              }) : (
+                <div className="lobby-panel-surface rounded-xl border border-dashed border-border/70 p-4 text-sm text-muted-foreground sm:col-span-2 lg:col-span-4">
+                  {language === "zh" ? "还没有真实牌局记录。进入任意桌台完成一局后，这里会显示最近结算。" : "No real rounds yet. Finish a table round and the latest settlement will appear here."}
+                </div>
+              )}
             </div>
           </section>
 

--- a/components/roulette-table-page.tsx
+++ b/components/roulette-table-page.tsx
@@ -7,6 +7,8 @@ import { ArrowLeft, BookOpen, RotateCcw, Settings, Trash2 } from "lucide-react"
 import { useLanguage } from "@/hooks/use-language"
 import { type Language } from "@/lib/home-content"
 import { type CasinoTableEntry } from "@/lib/game-catalog"
+import { type MemberGameProgress, type MemberTableSession } from "@/lib/member-data"
+import { cashOutClientTableSession, openClientTableSession } from "@/lib/table-session-client"
 import { cn } from "@/lib/utils"
 
 interface RouletteBet {
@@ -44,6 +46,20 @@ const initialStats: RouletteStats = {
   totalStake: 0,
   totalDelta: 0,
   lastDelta: 0,
+}
+
+function statsFromProgress(progress: MemberGameProgress | null): RouletteStats {
+  if (!progress) {
+    return initialStats
+  }
+
+  return {
+    rounds: progress.plays,
+    hitRounds: progress.wins,
+    totalStake: 0,
+    totalDelta: progress.lastDelta,
+    lastDelta: progress.lastDelta,
+  }
 }
 
 function range(start: number, end: number) {
@@ -311,8 +327,12 @@ async function persistRouletteProgress(
   result: number,
   delta: number,
   bankroll: number,
+  totalStake: number,
+  bets: RouletteBet[],
+  idempotencyKey: string,
+  tableSessionId?: string,
 ) {
-  await fetch("/api/member/progress", {
+  const response = await fetch("/api/member/progress", {
     method: "POST",
     headers: { "content-type": "application/json" },
     body: JSON.stringify({
@@ -321,16 +341,40 @@ async function persistRouletteProgress(
       delta,
       bankroll,
       summary: `Roulette ${result} ${numberColor(result)}; ${formatDelta(delta)}`,
+      idempotencyKey,
+      tableSessionId,
+      totalStake,
+      betSnapshot: {
+        bets,
+        totalStake,
+      },
+      resultSnapshot: {
+        result,
+        color: numberColor(result),
+      },
     }),
   }).catch(() => null)
+
+  if (!response?.ok) {
+    return null
+  }
+
+  const payload = (await response.json().catch(() => null)) as { progress?: { bankroll?: unknown } } | null
+  return typeof payload?.progress?.bankroll === "number" ? payload.progress.bankroll : null
 }
 
 export function RouletteTablePage({
   entry,
   defaultLanguage,
+  initialWalletBalance,
+  initialProgress,
+  initialTableSession,
 }: {
   entry: CasinoTableEntry
   defaultLanguage: Language
+  initialWalletBalance: number
+  initialProgress: MemberGameProgress | null
+  initialTableSession: MemberTableSession | null
 }) {
   const [language] = useLanguage(defaultLanguage)
   const isChinese = language === "zh"
@@ -342,10 +386,16 @@ export function RouletteTablePage({
   const ballAngle = useRef<number | null>(null)
   const ballRadius = useRef(ballPocketRadius)
   const pointerNumberRef = useRef<number | null>(null)
-  const [bankroll, setBankroll] = useState(1000)
+  const initialBankroll = initialTableSession?.chipBalance ?? 0
+  const [bankroll, setBankroll] = useState(initialBankroll)
+  const [walletBalance, setWalletBalance] = useState(initialWalletBalance)
+  const [tableSession, setTableSession] = useState<MemberTableSession | null>(initialTableSession)
+  const [buyInAmount, setBuyInAmount] = useState(100)
+  const [isOpeningSession, setIsOpeningSession] = useState(false)
+  const [isCashingOut, setIsCashingOut] = useState(false)
   const [stake, setStake] = useState(50)
   const [chips, setChips] = useState(defaultChips)
-  const [initialBankrollInput, setInitialBankrollInput] = useState("1000")
+  const [initialBankrollInput, setInitialBankrollInput] = useState(String(initialBankroll))
   const [initialChipsInput, setInitialChipsInput] = useState(defaultChips.join(","))
   const [bets, setBets] = useState<RouletteBet[]>([])
   const [result, setResult] = useState<number | null>(null)
@@ -355,7 +405,7 @@ export function RouletteTablePage({
     isChinese ? "可同局叠加多个下注项目。" : "Multiple bets can be stacked in the same spin.",
   )
   const [spinning, setSpinning] = useState(false)
-  const [stats, setStats] = useState<RouletteStats>(initialStats)
+  const [stats, setStats] = useState<RouletteStats>(() => statsFromProgress(initialProgress))
   const [showRules, setShowRules] = useState(false)
   const [insideTypeA, setInsideTypeA] = useState<"split" | "street">("split")
   const [insideIndexA, setInsideIndexA] = useState(0)
@@ -392,54 +442,77 @@ export function RouletteTablePage({
   }, [])
 
   useEffect(() => {
-    const saved = window.localStorage.getItem(storageKey)
+    if (!initialTableSession) {
+      window.localStorage.removeItem(storageKey)
+      setWalletBalance(initialWalletBalance)
+      setTableSession(null)
+      setBankroll(0)
+      setInitialBankrollInput("0")
+      setBets([])
+      setResult(null)
+      setPointerNumber(null)
+      pointerNumberRef.current = null
+      setSpinProgress(0)
+      setSpinning(false)
 
-    if (!saved) {
+      if (initialProgress) {
+        setStats(statsFromProgress(initialProgress))
+      }
+
       return
     }
 
-    try {
-      const parsed = JSON.parse(saved) as {
-        bankroll?: number
-        stake?: number
-        chips?: number[]
-        stats?: RouletteStats
-        result?: number | null
-        wheelAngle?: number
-      }
+    const saved = window.localStorage.getItem(storageKey)
 
-      if (typeof parsed.bankroll === "number") {
-        setBankroll(parsed.bankroll)
-        setInitialBankrollInput(String(parsed.bankroll))
-      }
+    if (saved) {
+      try {
+        const parsed = JSON.parse(saved) as {
+          bankroll?: number
+          stake?: number
+          chips?: number[]
+          stats?: RouletteStats
+          result?: number | null
+          wheelAngle?: number
+        }
 
-      if (typeof parsed.stake === "number") {
-        setStake(parsed.stake)
-      }
+        if (typeof parsed.stake === "number") {
+          setStake(parsed.stake)
+        }
 
-      if (Array.isArray(parsed.chips) && parsed.chips.every((chip) => typeof chip === "number")) {
-        setChips(parsed.chips)
-        setInitialChipsInput(parsed.chips.join(","))
-      }
+        if (Array.isArray(parsed.chips) && parsed.chips.every((chip) => typeof chip === "number")) {
+          setChips(parsed.chips)
+          setInitialChipsInput(parsed.chips.join(","))
+        }
 
-      if (parsed.stats) {
-        setStats(parsed.stats)
-      }
+        if (parsed.stats) {
+          setStats(parsed.stats)
+        }
 
-      if (typeof parsed.result === "number" || parsed.result === null) {
-        setResult(parsed.result)
-        setPointerNumber(parsed.result)
-        pointerNumberRef.current = parsed.result
-      }
+        if (typeof parsed.result === "number" || parsed.result === null) {
+          setResult(parsed.result)
+          setPointerNumber(parsed.result)
+          pointerNumberRef.current = parsed.result
+        }
 
-      if (typeof parsed.wheelAngle === "number") {
-        wheelAngle.current = parsed.wheelAngle
-        updatePointerNumber(parsed.wheelAngle)
+        if (typeof parsed.wheelAngle === "number") {
+          wheelAngle.current = parsed.wheelAngle
+          updatePointerNumber(parsed.wheelAngle)
+        }
+      } catch {
+        window.localStorage.removeItem(storageKey)
       }
-    } catch {
-      window.localStorage.removeItem(storageKey)
     }
-  }, [storageKey])
+
+    const syncedBankroll = initialTableSession.chipBalance
+    setWalletBalance(initialWalletBalance)
+    setTableSession(initialTableSession)
+    setBankroll(syncedBankroll)
+    setInitialBankrollInput(String(syncedBankroll))
+
+    if (initialProgress) {
+      setStats(statsFromProgress(initialProgress))
+    }
+  }, [storageKey, initialProgress, initialWalletBalance, initialTableSession])
 
   function persistLocal(
     nextBankroll: number,
@@ -460,8 +533,70 @@ export function RouletteTablePage({
     )
   }
 
+  async function openSession() {
+    const amount = Math.min(1000000, Math.max(1, Math.round(Number(buyInAmount) * 100) / 100))
+
+    if (amount > walletBalance) {
+      setMessage(isChinese ? "钱包余额不足，无法买入这笔筹码。" : "Wallet balance is not enough for this buy-in.")
+      return
+    }
+
+    setIsOpeningSession(true)
+    setMessage(isChinese ? "正在从钱包买入桌台筹码..." : "Buying chips from your wallet...")
+
+    try {
+      const result = await openClientTableSession(entry.slug, amount, "roulette-buy-in")
+
+      setTableSession(result.tableSession)
+      setBankroll(result.tableSession.chipBalance)
+      setInitialBankrollInput(String(result.tableSession.chipBalance))
+      setWalletBalance(result.walletBalance ?? walletBalance - amount)
+      setBets([])
+      setResult(null)
+      setPointerNumber(null)
+      pointerNumberRef.current = null
+      setSpinProgress(0)
+      window.localStorage.removeItem(storageKey)
+      setMessage(isChinese ? "买入成功，桌台筹码已准备好。" : "Buy-in complete. Table chips are ready.")
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : isChinese ? "买入失败。" : "Buy-in failed.")
+    } finally {
+      setIsOpeningSession(false)
+    }
+  }
+
+  async function cashOutSession() {
+    if (!tableSession || isCashingOut || spinning) {
+      return
+    }
+
+    setIsCashingOut(true)
+    setMessage(isChinese ? "正在带走筹码并结算回钱包..." : "Cashing out table chips to your wallet...")
+
+    try {
+      const result = await cashOutClientTableSession(tableSession.id, "roulette-cash-out")
+
+      setTableSession(null)
+      setBankroll(0)
+      setInitialBankrollInput("0")
+      setWalletBalance(result.walletBalance ?? walletBalance + tableSession.chipBalance)
+      setBets([])
+      window.localStorage.removeItem(storageKey)
+      setMessage(isChinese ? "筹码已带走，余额已回到钱包。" : "Chips cashed out. Balance returned to wallet.")
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : isChinese ? "离桌失败。" : "Cash-out failed.")
+    } finally {
+      setIsCashingOut(false)
+    }
+  }
+
   function upsertBet(base: Omit<RouletteBet, "amount">) {
     if (spinning) {
+      return
+    }
+
+    if (!tableSession) {
+      setMessage(isChinese ? "请先从钱包买入筹码再入桌。" : "Buy in from your wallet before playing this table.")
       return
     }
 
@@ -512,8 +647,10 @@ export function RouletteTablePage({
       return
     }
 
-    setBankroll(1000)
-    setInitialBankrollInput("1000")
+    const nextBankroll = tableSession?.chipBalance ?? 0
+
+    setBankroll(nextBankroll)
+    setInitialBankrollInput(String(nextBankroll))
     setChips(defaultChips)
     setInitialChipsInput(defaultChips.join(","))
     setStake(50)
@@ -536,7 +673,7 @@ export function RouletteTablePage({
       return
     }
 
-    const nextBankroll = clampInt(initialBankrollInput, 1000)
+    const nextBankroll = tableSession?.chipBalance ?? 0
     const nextChips = parseChips(initialChipsInput, defaultChips)
 
     setBankroll(nextBankroll)
@@ -578,6 +715,12 @@ export function RouletteTablePage({
     if (spinning) {
       return
     }
+
+    if (!tableSession) {
+      setMessage(isChinese ? "请先从钱包买入筹码再入桌。" : "Buy in from your wallet before playing this table.")
+      return
+    }
+    const activeTableSession = tableSession
 
     if (!bets.length) {
       setMessage(isChinese ? "请先添加下注。" : "Place a bet first.")
@@ -682,6 +825,7 @@ export function RouletteTablePage({
 
         setResult(settledResult)
         setBankroll(nextBankroll)
+        setTableSession({ ...activeTableSession, chipBalance: nextBankroll })
         setStats(nextStats)
         setSpinProgress(100)
         setSpinning(false)
@@ -691,7 +835,22 @@ export function RouletteTablePage({
             : `Landed on ${settledResult} ${numberColor(settledResult)}, round ${formatDelta(delta)}.`,
         )
         persistLocal(nextBankroll, nextStats, settledResult, finalWheelAngle)
-        void persistRouletteProgress(entry, settledResult, delta, nextBankroll)
+        void persistRouletteProgress(
+          entry,
+          settledResult,
+          delta,
+          nextBankroll,
+          preview.totalStake,
+          bets,
+          `roulette-${entry.slug}-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+          activeTableSession.id,
+        ).then((serverBankroll) => {
+          if (typeof serverBankroll === "number") {
+            setBankroll(serverBankroll)
+            setTableSession((current) => current ? { ...current, chipBalance: serverBankroll } : current)
+            persistLocal(serverBankroll, nextStats, settledResult, finalWheelAngle)
+          }
+        })
       }, settleDelay)
     }
 
@@ -761,6 +920,76 @@ export function RouletteTablePage({
           </div>
         </header>
 
+        {!tableSession ? (
+          <section className="rounded-lg border border-[#d0b06e]/35 bg-black/25 p-5 shadow-[0_18px_50px_rgba(0,0,0,0.28)]">
+            <div className="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
+              <div>
+                <p className="text-sm font-black uppercase tracking-[0.16em] text-[#d0b06e]">
+                  {isChinese ? "买入筹码" : "Table buy-in"}
+                </p>
+                <h2 className="mt-2 text-2xl font-black text-[#fff4d8]">
+                  {isChinese ? "先从钱包买入本桌筹码" : "Buy chips before joining this table"}
+                </h2>
+                <p className="mt-2 max-w-2xl text-sm leading-6 text-[#cbbd91]">
+                  {isChinese
+                    ? "轮盘下注只使用桌台筹码，离桌时再把剩余筹码带回钱包。"
+                    : "Roulette bets use table chips, then remaining chips return to your wallet when you cash out."}
+                </p>
+                <p className="mt-3 text-sm font-black text-[#f4d18a]">
+                  {isChinese ? "钱包余额" : "Wallet"} {formatMoney(walletBalance)}
+                </p>
+              </div>
+
+              <form
+                action="/api/member/table-sessions"
+                method="post"
+                className="flex flex-col gap-3 sm:flex-row sm:items-end"
+                onSubmit={(event) => {
+                  event.preventDefault()
+                  void openSession()
+                }}
+              >
+                <input type="hidden" name="gameSlug" value={entry.slug} />
+                <div className="space-y-2">
+                  <label htmlFor="rouletteBuyInAmount" className="text-sm font-black text-[#fff4d8]">
+                    {isChinese ? "买入金额" : "Buy-in amount"}
+                  </label>
+                  <input
+                    id="rouletteBuyInAmount"
+                    name="buyInAmount"
+                    type="number"
+                    min={1}
+                    max={1000000}
+                    step={1}
+                    value={buyInAmount}
+                    onChange={(event) => setBuyInAmount(Number(event.target.value))}
+                    className="h-11 w-44 rounded-lg border border-[#d0b06e]/35 bg-black/30 px-3 text-base font-black text-[#fff4d8] outline-none transition focus:border-[#f0cf83]"
+                  />
+                </div>
+                <div className="flex gap-2">
+                  {[100, 250, 500].map((amount) => (
+                    <button
+                      key={amount}
+                      type="button"
+                      onClick={() => setBuyInAmount(amount)}
+                      className="h-11 rounded-lg border border-[#d0b06e]/30 bg-black/20 px-3 text-sm font-black text-[#fff4d8] transition hover:bg-[#d0b06e]/15"
+                    >
+                      {formatMoney(amount)}
+                    </button>
+                  ))}
+                </div>
+                <button
+                  type="submit"
+                  disabled={isOpeningSession}
+                  className="h-11 rounded-lg bg-[#f0cf83] px-5 text-sm font-black text-[#1c160c] transition hover:bg-[#ffd98c] disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {isOpeningSession ? (isChinese ? "买入中..." : "Buying in...") : isChinese ? "买入并入桌" : "Buy in"}
+                </button>
+              </form>
+            </div>
+          </section>
+        ) : null}
+
         <section className="grid gap-3 lg:grid-cols-2">
           <div className="rounded-lg border border-[#d0b06e]/30 bg-white/[0.035] p-4 shadow-[0_18px_50px_rgba(0,0,0,0.34)] backdrop-blur">
             <div className="flex flex-wrap items-start justify-between gap-4">
@@ -768,15 +997,28 @@ export function RouletteTablePage({
                 <p className="text-sm font-black uppercase tracking-[0.16em] text-[#d0b06e]">
                   {isChinese ? "资金与旋转" : "Bankroll & Spin"}
                 </p>
-                <p className="mt-3 text-sm text-[#cbbd91]">{isChinese ? "余额" : "Balance"}</p>
+                <p className="mt-3 text-sm text-[#cbbd91]">{isChinese ? "桌台筹码" : "Table chips"}</p>
                 <p className="text-5xl font-black leading-none text-[#f4d18a] md:text-6xl">
                   {formatMoney(bankroll)}
                 </p>
+                <p className="mt-2 text-xs font-bold text-[#cbbd91]">
+                  {isChinese ? "钱包" : "Wallet"} {formatMoney(walletBalance)}
+                </p>
               </div>
+              {tableSession ? (
+                <button
+                  type="button"
+                  onClick={cashOutSession}
+                  disabled={spinning || isCashingOut}
+                  className="inline-flex min-h-12 items-center rounded-lg border border-[#d0b06e]/35 bg-[#173727] px-4 text-sm font-black text-[#fff4d8] transition hover:bg-[#214a35] disabled:cursor-not-allowed disabled:opacity-55"
+                >
+                  {isCashingOut ? (isChinese ? "离桌中..." : "Cashing out...") : isChinese ? "带走筹码" : "Cash out"}
+                </button>
+              ) : null}
               <button
                 type="button"
                 onClick={spin}
-                disabled={spinning}
+                disabled={spinning || !tableSession}
                 className="inline-flex min-h-12 items-center rounded-lg border border-[#d0b06e]/50 bg-gradient-to-b from-[#f0cf83] to-[#c69d55] px-5 text-base font-black text-[#34240a] shadow-[0_14px_28px_rgba(0,0,0,0.26)] transition hover:brightness-105 disabled:cursor-not-allowed disabled:opacity-55"
               >
                 {spinning ? (isChinese ? "旋转中" : "Spinning") : isChinese ? "旋转结算" : "Spin"}
@@ -897,7 +1139,7 @@ export function RouletteTablePage({
               min={100}
               step={100}
               value={initialBankrollInput}
-              disabled={spinning}
+              disabled
               onChange={(event) => setInitialBankrollInput(event.target.value)}
               className="h-10 w-36 rounded-lg border border-[#d0b06e]/35 bg-black/25 px-3 text-base font-black text-[#fff4d8] outline-none transition focus:border-[#f0cf83] disabled:cursor-not-allowed disabled:opacity-55"
             />

--- a/lib/home-content.ts
+++ b/lib/home-content.ts
@@ -133,12 +133,12 @@ export function getNavItems(language: Language) {
   return language === "zh"
     ? [
         { label: "游戏大厅", href: "#games", active: true },
-        { label: "实时动态", href: "#leaderboard" },
+        { label: "一周输赢榜", href: "#leaderboard" },
         { label: "最近记录", href: "#history" },
       ]
     : [
         { label: "Lobby", href: "#games", active: true },
-        { label: "Live", href: "#leaderboard" },
+        { label: "Weekly P&L", href: "#leaderboard" },
         { label: "History", href: "#history" },
       ]
 }
@@ -269,8 +269,8 @@ export function getHomeCopy(language: Language, viewerMode: ViewerMode) {
       gamesSubheading: language === "zh" ? "玩家主页面" : "Player Home",
       gamesViewAll: language === "zh" ? "查看记录" : "View activity",
       quickActions: language === "zh" ? "推荐动作" : "Recommended Actions",
-      liveWins: language === "zh" ? "实时动态" : "Live Activity",
-      liveBadge: language === "zh" ? "实时" : "Live",
+      liveWins: language === "zh" ? "一周输赢榜" : "Weekly P&L",
+      liveBadge: language === "zh" ? "近 7 天" : "7 days",
       history: language === "zh" ? "最近记录" : "Recent Activity",
       historyViewAll: language === "zh" ? "返回顶部" : "Back to top",
       footerTagline: language === "zh" ? "TaihuCasino · 会员游戏大厅" : "TaihuCasino · Member game lobby",

--- a/lib/member-data.ts
+++ b/lib/member-data.ts
@@ -1066,16 +1066,46 @@ export async function cashOutTableSession(
   }
 }
 
-async function applySupabaseTableSessionDelta(auth: AuthenticatedMember, sessionId: string, delta: number) {
+async function settleSupabaseTableSessionRound(
+  auth: AuthenticatedMember,
+  {
+    sessionId,
+    gameSlug,
+    outcome,
+    delta,
+    totalStake,
+    summary,
+    betSnapshot,
+    resultSnapshot,
+    idempotencyKey,
+  }: {
+    sessionId: string
+    gameSlug: string
+    outcome: ProgressOutcome
+    delta: number
+    totalStake: number
+    summary: string
+    betSnapshot: Record<string, unknown>
+    resultSnapshot: Record<string, unknown>
+    idempotencyKey: string | null
+  },
+) {
   if (!auth.session.userId) {
     throw new Error("Supabase member session is missing a user id.")
   }
 
   const serviceSupabase = createSupabaseServiceClient()
-  const { data, error } = await serviceSupabase.rpc("apply_member_table_session_delta", {
+  const { data, error } = await serviceSupabase.rpc("settle_member_table_session_round", {
     p_user_id: auth.session.userId,
     p_session_id: sessionId,
+    p_game_slug: gameSlug,
+    p_outcome: outcome,
     p_delta: delta,
+    p_total_stake: totalStake,
+    p_summary: summary,
+    p_bet_snapshot: betSnapshot,
+    p_result_snapshot: resultSnapshot,
+    p_idempotency_key: idempotencyKey,
   })
 
   if (error) {
@@ -1083,20 +1113,25 @@ async function applySupabaseTableSessionDelta(auth: AuthenticatedMember, session
   }
 
   if (!data || typeof data !== "object" || Array.isArray(data)) {
-    throw new Error("Table session service returned an invalid response.")
+    throw new Error("Table round service returned an invalid response.")
   }
 
   const payload = data as Record<string, unknown>
+  const progressPayload = payload.progress
   const sessionPayload = payload.session
 
+  if (!progressPayload || typeof progressPayload !== "object" || Array.isArray(progressPayload)) {
+    throw new Error("Table round service returned an invalid progress record.")
+  }
+
   if (!sessionPayload || typeof sessionPayload !== "object" || Array.isArray(sessionPayload)) {
-    throw new Error("Table session service returned an invalid session.")
+    throw new Error("Table round service returned an invalid table session.")
   }
 
   return {
+    progress: toProgress(progressPayload as Record<string, unknown>),
     tableSession: toTableSession(sessionPayload as Record<string, unknown>),
-    chipBalanceBefore: normalizeMoney(payload.chip_balance_before),
-    chipBalanceAfter: normalizeMoney(payload.chip_balance_after),
+    idempotent: payload.idempotent === true,
   }
 }
 
@@ -1509,82 +1544,19 @@ export async function recordGameProgress(cookieStore: CookieStore, response: Nex
     }
 
     if (tableSessionId) {
-      const existingRound =
-        idempotencyKey ? await findSupabaseRoundByIdempotencyKey(userId, idempotencyKey) : null
-      const { data: existing, error: existingError } = await auth.supabase
-        .from("member_game_progress")
-        .select("*")
-        .eq("user_id", userId)
-        .eq("game_slug", gameSlug)
-        .maybeSingle()
-
-      if (existingError) {
-        throw new Error(existingError.message)
-      }
-
-      const current = existing ? toProgress(existing) : null
-
-      if (existingRound && current) {
-        return current
-      }
-
-      const tableResult = await applySupabaseTableSessionDelta(auth, tableSessionId, delta)
-      const bankroll = tableResult.chipBalanceAfter
-      const streak = outcome === "win" ? (current?.streak ?? 0) + 1 : outcome === "loss" ? 0 : current?.streak ?? 0
-      const progress = {
-        user_id: userId,
-        game_slug: gameSlug,
-        plays: (current?.plays ?? 0) + 1,
-        wins: (current?.wins ?? 0) + (outcome === "win" ? 1 : 0),
-        losses: (current?.losses ?? 0) + (outcome === "loss" ? 1 : 0),
-        streak,
-        best_streak: Math.max(current?.bestStreak ?? 0, streak),
-        bankroll,
-        last_result: outcome,
-        last_delta: delta,
-        last_summary: summary,
-        last_played_at: playedAt,
-      }
-      const { data, error } = await auth.supabase.from("member_game_progress").upsert(progress).select("*").single()
-
-      if (error) {
-        throw new Error(error.message)
-      }
-
-      await insertSupabaseGameRound({
-        userId,
+      const tableRound = await settleSupabaseTableSessionRound(auth, {
+        sessionId: tableSessionId,
         gameSlug,
-        tableSessionId,
         outcome,
         delta,
         totalStake,
-        chipBalanceBefore: tableResult.chipBalanceBefore,
-        chipBalanceAfter: tableResult.chipBalanceAfter,
         summary,
         betSnapshot,
-        resultSnapshot: {
-          ...resultSnapshot,
-          tableSessionId,
-          chipBalanceBefore: tableResult.chipBalanceBefore,
-          chipBalanceAfter: tableResult.chipBalanceAfter,
-        },
+        resultSnapshot,
         idempotencyKey,
       })
 
-      const { error: eventError } = await auth.supabase
-        .from("member_events")
-        .insert({
-          user_id: userId,
-          kind: event.kind,
-          title: event.title,
-          detail: event.detail,
-        })
-
-      if (eventError) {
-        throw new Error(eventError.message)
-      }
-
-      return toProgress(data)
+      return tableRound.progress
     }
 
     const walletEntry = await applyAuthenticatedWalletEntry(auth, cookieStore, response, {

--- a/lib/member-data.ts
+++ b/lib/member-data.ts
@@ -1,6 +1,6 @@
 import "server-only"
 
-import { createHmac, timingSafeEqual } from "node:crypto"
+import { createHmac, randomUUID, timingSafeEqual } from "node:crypto"
 
 import type { SupabaseClient } from "@supabase/supabase-js"
 import type { cookies } from "next/headers"
@@ -11,6 +11,7 @@ import {
   MEMBER_SESSION_COOKIE,
   createSessionFromSupabaseUser,
   createSupabaseAuthClient,
+  createSupabaseServiceClient,
   getSessionSecret,
   isSupabaseAuthConfigured,
   readSessionToken,
@@ -22,6 +23,19 @@ export type MemberTheme = "light" | "dark" | "system"
 export type MemberLanguage = "zh" | "en"
 export type ProfileVisibility = "private" | "friends" | "public"
 export type ProgressOutcome = "win" | "loss" | "push"
+export type WalletLedgerSource =
+  | "game_round"
+  | "ad_reward"
+  | "purchase"
+  | "admin_adjustment"
+  | "system"
+  | "table_buy_in"
+  | "table_cash_out"
+export type GameRoundStatus = "settled" | "rejected" | "voided"
+export type TableSessionStatus = "active" | "cashed_out" | "abandoned"
+export type AdRewardPlacement = "daily_bonus" | "loss_recovery" | "lobby_reward"
+export type AdRewardStatus = "started" | "completed" | "credited" | "failed"
+export type PurchaseStatus = "created" | "succeeded" | "failed" | "canceled" | "credited"
 
 export interface MemberProfile {
   id: string
@@ -76,6 +90,97 @@ export interface MemberEvent {
   createdAt: string
 }
 
+export interface MemberWalletLedgerEntry {
+  id: string
+  source: WalletLedgerSource
+  amount: number
+  balanceBefore: number
+  balanceAfter: number
+  currency: "USD"
+  referenceId: string | null
+  idempotencyKey: string | null
+  metadata: Record<string, unknown>
+  createdAt: string
+}
+
+export interface MemberGameRound {
+  id: string
+  gameSlug: string
+  tableSessionId: string | null
+  roundStatus: GameRoundStatus
+  totalStake: number
+  delta: number
+  outcome: ProgressOutcome
+  chipBalanceBefore: number | null
+  chipBalanceAfter: number | null
+  resultSummary: string
+  betSnapshot: Record<string, unknown>
+  resultSnapshot: Record<string, unknown>
+  idempotencyKey: string | null
+  createdAt: string
+}
+
+export interface MemberTableSession {
+  id: string
+  gameSlug: string
+  status: TableSessionStatus
+  buyInAmount: number
+  chipBalance: number
+  walletLedgerId: string | null
+  cashOutLedgerId: string | null
+  idempotencyKey: string | null
+  metadata: Record<string, unknown>
+  openedAt: string
+  closedAt: string | null
+  updatedAt: string
+}
+
+export interface TableSessionMutationResult {
+  tableSession: MemberTableSession
+  walletEntry: WalletEntryResult | null
+  wallet: MemberWallet | null
+  idempotent: boolean
+}
+
+export interface MemberAdReward {
+  id: string
+  placement: AdRewardPlacement
+  rewardAmount: number
+  status: AdRewardStatus
+  createdAt: string
+  creditedAt: string | null
+}
+
+export interface MemberPurchase {
+  id: string
+  productId: string
+  amount: number
+  credits: number
+  status: PurchaseStatus
+  provider: string
+  providerReference: string | null
+  createdAt: string
+  creditedAt: string | null
+}
+
+export interface WalletEntryInput {
+  source: WalletLedgerSource
+  amount: number
+  referenceId?: string | null
+  idempotencyKey?: string | null
+  metadata?: Record<string, unknown>
+}
+
+export interface WalletEntryResult {
+  ledgerId: string
+  balanceBefore: number
+  balanceAfter: number
+  amount: number
+  currency: "USD"
+  idempotent: boolean
+  createdAt: string
+}
+
 export interface MemberOverview {
   session: MemberSession
   profile: MemberProfile
@@ -83,6 +188,10 @@ export interface MemberOverview {
   wallet: MemberWallet
   progress: MemberGameProgress[]
   recentEvents: MemberEvent[]
+  walletLedger: MemberWalletLedgerEntry[]
+  gameRounds: MemberGameRound[]
+  adRewards: MemberAdReward[]
+  purchases: MemberPurchase[]
 }
 
 interface AuthenticatedMember {
@@ -97,12 +206,19 @@ interface LocalMemberState {
   wallet?: Partial<MemberWallet>
   progress?: MemberGameProgress[]
   recentEvents?: MemberEvent[]
+  walletLedger?: MemberWalletLedgerEntry[]
+  gameRounds?: MemberGameRound[]
+  adRewards?: MemberAdReward[]
+  purchases?: MemberPurchase[]
+  tableSessions?: MemberTableSession[]
 }
 
 export const MEMBER_STATE_COOKIE = "taihu-member-state"
 const MEMBER_STATE_MAX_AGE_SECONDS = 60 * 60 * 24 * 30
 const LOCAL_STATE_PROGRESS_LIMIT = 4
 const LOCAL_STATE_EVENT_LIMIT = 3
+const LOCAL_STATE_ROUND_LIMIT = 12
+const LOCAL_STATE_TABLE_SESSION_LIMIT = 8
 const LOCAL_STATE_SUMMARY_LIMIT = 120
 
 function nowIso() {
@@ -179,6 +295,17 @@ function compactLocalEvents(events: MemberEvent[]) {
     title: event.title.slice(0, 80),
     detail: event.detail.slice(0, LOCAL_STATE_SUMMARY_LIMIT),
   }))
+}
+
+function compactLocalGameRounds(rounds: MemberGameRound[]) {
+  return rounds.slice(0, LOCAL_STATE_ROUND_LIMIT).map((round) => ({
+    ...round,
+    resultSummary: round.resultSummary.slice(0, LOCAL_STATE_SUMMARY_LIMIT),
+  }))
+}
+
+function compactLocalTableSessions(sessions: MemberTableSession[]) {
+  return sessions.slice(0, LOCAL_STATE_TABLE_SESSION_LIMIT)
 }
 
 function defaultSettings(): MemberSettings {
@@ -264,6 +391,28 @@ function normalizeNumber(value: unknown, fallback: number, min: number, max: num
   return Math.min(max, Math.max(min, Math.round(numeric)))
 }
 
+function normalizeMoney(value: unknown, fallback = 0) {
+  const numeric = typeof value === "number" ? value : Number(value)
+
+  return Number.isFinite(numeric) ? numeric : fallback
+}
+
+function normalizeRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {}
+}
+
+function formatSupabaseError(error: unknown) {
+  if (error instanceof Error) {
+    return error.message
+  }
+
+  if (error && typeof error === "object" && "message" in error && typeof error.message === "string") {
+    return error.message
+  }
+
+  return "unknown error"
+}
+
 function mergeSettings(settings?: Partial<MemberSettings>): MemberSettings {
   const defaults = defaultSettings()
 
@@ -320,8 +469,8 @@ function toWallet(row?: Record<string, unknown> | null): MemberWallet {
 
   return {
     currency: "USD",
-    balance: typeof row?.balance === "number" ? row.balance : fallback.balance,
-    bonusBalance: typeof row?.bonus_balance === "number" ? row.bonus_balance : fallback.bonusBalance,
+    balance: normalizeMoney(row?.balance, fallback.balance),
+    bonusBalance: normalizeMoney(row?.bonus_balance, fallback.bonusBalance),
     updatedAt: typeof row?.updated_at === "string" ? row.updated_at : fallback.updatedAt,
   }
 }
@@ -352,6 +501,602 @@ function toEvent(row: Record<string, unknown>): MemberEvent {
     title: typeof row.title === "string" ? row.title : "Member event",
     detail: typeof row.detail === "string" ? row.detail : "",
     createdAt: typeof row.created_at === "string" ? row.created_at : nowIso(),
+  }
+}
+
+function toWalletLedgerEntry(row: Record<string, unknown>): MemberWalletLedgerEntry {
+  const source =
+    row.source === "game_round" ||
+    row.source === "ad_reward" ||
+    row.source === "purchase" ||
+    row.source === "admin_adjustment" ||
+    row.source === "system" ||
+    row.source === "table_buy_in" ||
+    row.source === "table_cash_out"
+      ? row.source
+      : "system"
+
+  return {
+    id: String(row.id ?? `${Date.now()}`),
+    source,
+    amount: normalizeMoney(row.amount),
+    balanceBefore: normalizeMoney(row.balance_before),
+    balanceAfter: normalizeMoney(row.balance_after),
+    currency: "USD",
+    referenceId: typeof row.reference_id === "string" ? row.reference_id : null,
+    idempotencyKey: typeof row.idempotency_key === "string" ? row.idempotency_key : null,
+    metadata: normalizeRecord(row.metadata),
+    createdAt: typeof row.created_at === "string" ? row.created_at : nowIso(),
+  }
+}
+
+function toGameRound(row: Record<string, unknown>): MemberGameRound {
+  const roundStatus =
+    row.round_status === "rejected" || row.round_status === "voided" ? row.round_status : "settled"
+  const outcome =
+    row.outcome === "win" || row.outcome === "loss" || row.outcome === "push" ? row.outcome : "push"
+
+  return {
+    id: String(row.id ?? `${Date.now()}`),
+    gameSlug: String(row.game_slug ?? ""),
+    tableSessionId: typeof row.table_session_id === "string" ? row.table_session_id : null,
+    roundStatus,
+    totalStake: normalizeMoney(row.total_stake),
+    delta: normalizeMoney(row.delta),
+    outcome,
+    chipBalanceBefore: row.chip_balance_before === null || row.chip_balance_before === undefined ? null : normalizeMoney(row.chip_balance_before),
+    chipBalanceAfter: row.chip_balance_after === null || row.chip_balance_after === undefined ? null : normalizeMoney(row.chip_balance_after),
+    resultSummary: typeof row.result_summary === "string" ? row.result_summary : "",
+    betSnapshot: normalizeRecord(row.bet_snapshot),
+    resultSnapshot: normalizeRecord(row.result_snapshot),
+    idempotencyKey: typeof row.idempotency_key === "string" ? row.idempotency_key : null,
+    createdAt: typeof row.created_at === "string" ? row.created_at : nowIso(),
+  }
+}
+
+function toTableSession(row: Record<string, unknown>): MemberTableSession {
+  const status =
+    row.status === "cashed_out" || row.status === "abandoned" ? row.status : "active"
+
+  return {
+    id: String(row.id ?? `${Date.now()}`),
+    gameSlug: String(row.game_slug ?? ""),
+    status,
+    buyInAmount: normalizeMoney(row.buy_in_amount),
+    chipBalance: normalizeMoney(row.chip_balance),
+    walletLedgerId: typeof row.wallet_ledger_id === "string" ? row.wallet_ledger_id : null,
+    cashOutLedgerId: typeof row.cash_out_ledger_id === "string" ? row.cash_out_ledger_id : null,
+    idempotencyKey: typeof row.idempotency_key === "string" ? row.idempotency_key : null,
+    metadata: normalizeRecord(row.metadata),
+    openedAt: typeof row.opened_at === "string" ? row.opened_at : nowIso(),
+    closedAt: typeof row.closed_at === "string" ? row.closed_at : null,
+    updatedAt: typeof row.updated_at === "string" ? row.updated_at : nowIso(),
+  }
+}
+
+function toAdReward(row: Record<string, unknown>): MemberAdReward {
+  const placement =
+    row.placement === "loss_recovery" || row.placement === "lobby_reward" ? row.placement : "daily_bonus"
+  const status =
+    row.status === "started" || row.status === "completed" || row.status === "credited" || row.status === "failed"
+      ? row.status
+      : "started"
+
+  return {
+    id: String(row.id ?? `${Date.now()}`),
+    placement,
+    rewardAmount: normalizeMoney(row.reward_amount),
+    status,
+    createdAt: typeof row.created_at === "string" ? row.created_at : nowIso(),
+    creditedAt: typeof row.credited_at === "string" ? row.credited_at : null,
+  }
+}
+
+function toPurchase(row: Record<string, unknown>): MemberPurchase {
+  const status =
+    row.status === "succeeded" ||
+    row.status === "failed" ||
+    row.status === "canceled" ||
+    row.status === "credited"
+      ? row.status
+      : "created"
+
+  return {
+    id: String(row.id ?? `${Date.now()}`),
+    productId: typeof row.product_id === "string" ? row.product_id : "",
+    amount: normalizeMoney(row.amount),
+    credits: normalizeMoney(row.credits),
+    status,
+    provider: typeof row.provider === "string" ? row.provider : "stub",
+    providerReference: typeof row.provider_reference === "string" ? row.provider_reference : null,
+    createdAt: typeof row.created_at === "string" ? row.created_at : nowIso(),
+    creditedAt: typeof row.credited_at === "string" ? row.credited_at : null,
+  }
+}
+
+function toWalletEntryResult(row: Record<string, unknown>): WalletEntryResult {
+  return {
+    ledgerId: String(row.ledger_id ?? row.id ?? `${Date.now()}`),
+    balanceBefore: normalizeMoney(row.balance_before),
+    balanceAfter: normalizeMoney(row.balance_after),
+    amount: normalizeMoney(row.amount),
+    currency: "USD",
+    idempotent: row.idempotent === true,
+    createdAt: typeof row.created_at === "string" ? row.created_at : nowIso(),
+  }
+}
+
+async function applySupabaseWalletEntry(auth: AuthenticatedMember, input: WalletEntryInput): Promise<WalletEntryResult> {
+  if (!auth.session.userId) {
+    throw new Error("Supabase member session is missing a user id.")
+  }
+
+  const serviceSupabase = createSupabaseServiceClient()
+  const { data, error } = await serviceSupabase.rpc("apply_member_wallet_entry", {
+    p_user_id: auth.session.userId,
+    p_source: input.source,
+    p_amount: input.amount,
+    p_reference_id: input.referenceId ?? null,
+    p_idempotency_key: input.idempotencyKey ?? null,
+    p_metadata: input.metadata ?? {},
+  })
+
+  if (error) {
+    throw new Error(error.message)
+  }
+
+  if (!data || typeof data !== "object" || Array.isArray(data)) {
+    throw new Error("Wallet service returned an invalid response.")
+  }
+
+  return toWalletEntryResult(data as Record<string, unknown>)
+}
+
+function applyLocalWalletEntry(
+  auth: AuthenticatedMember,
+  cookieStore: CookieStore,
+  response: NextResponse,
+  input: WalletEntryInput,
+): WalletEntryResult {
+  const state = readStateToken(cookieStore.get(MEMBER_STATE_COOKIE)?.value)
+  const existingEntry =
+    input.idempotencyKey && state.walletLedger
+      ? state.walletLedger.find((entry) => entry.idempotencyKey === input.idempotencyKey)
+      : undefined
+
+  if (existingEntry) {
+    return {
+      ledgerId: existingEntry.id,
+      balanceBefore: existingEntry.balanceBefore,
+      balanceAfter: existingEntry.balanceAfter,
+      amount: existingEntry.amount,
+      currency: existingEntry.currency,
+      idempotent: true,
+      createdAt: existingEntry.createdAt,
+    }
+  }
+
+  const currentWallet = {
+    ...defaultWallet(),
+    ...state.wallet,
+    currency: "USD" as const,
+  }
+  const amount = normalizeMoney(input.amount)
+  const balanceBefore = currentWallet.balance
+  const balanceAfter = Math.round((balanceBefore + amount) * 100) / 100
+
+  if (balanceAfter < 0) {
+    throw new Error("Insufficient wallet balance.")
+  }
+
+  const createdAt = nowIso()
+  const ledgerEntry: MemberWalletLedgerEntry = {
+    id: `${createdAt}-${Math.random().toString(16).slice(2)}`,
+    source: input.source,
+    amount,
+    balanceBefore,
+    balanceAfter,
+    currency: "USD",
+    referenceId: input.referenceId ?? null,
+    idempotencyKey: input.idempotencyKey ?? null,
+    metadata: {
+      ...(input.metadata ?? {}),
+      sessionProvider: auth.session.provider ?? "local",
+    },
+    createdAt,
+  }
+
+  writeLocalState(response, {
+    ...state,
+    wallet: {
+      ...currentWallet,
+      balance: balanceAfter,
+      updatedAt: createdAt,
+    },
+    walletLedger: [ledgerEntry, ...(state.walletLedger ?? [])].slice(0, 12),
+  })
+
+  return {
+    ledgerId: ledgerEntry.id,
+    balanceBefore,
+    balanceAfter,
+    amount,
+    currency: "USD",
+    idempotent: false,
+    createdAt,
+  }
+}
+
+async function applyAuthenticatedWalletEntry(
+  auth: AuthenticatedMember,
+  cookieStore: CookieStore,
+  response: NextResponse,
+  input: WalletEntryInput,
+) {
+  if (auth.source === "supabase") {
+    return applySupabaseWalletEntry(auth, input)
+  }
+
+  return applyLocalWalletEntry(auth, cookieStore, response, input)
+}
+
+export async function applyWalletEntry(cookieStore: CookieStore, response: NextResponse, input: WalletEntryInput) {
+  const auth = await getAuthenticatedMember(cookieStore, response)
+
+  if (!auth) {
+    return null
+  }
+
+  return applyAuthenticatedWalletEntry(auth, cookieStore, response, input)
+}
+
+export async function readWallet(cookieStore: CookieStore, response?: NextResponse) {
+  const overview = await readMemberOverview(cookieStore, response)
+
+  return overview?.wallet ?? null
+}
+
+export async function readWalletLedger(cookieStore: CookieStore, limit = 12, response?: NextResponse) {
+  const overview = await readMemberOverview(cookieStore, response)
+
+  return overview ? overview.walletLedger.slice(0, Math.max(1, Math.min(50, limit))) : null
+}
+
+async function readAuthenticatedWallet(auth: AuthenticatedMember): Promise<MemberWallet> {
+  if (auth.source === "supabase") {
+    if (!auth.supabase || !auth.session.userId) {
+      throw new Error("Supabase member session is missing a user id.")
+    }
+
+    const { data, error } = await auth.supabase
+      .from("member_wallets")
+      .select("*")
+      .eq("user_id", auth.session.userId)
+      .maybeSingle()
+
+    if (error) {
+      throw new Error(error.message)
+    }
+
+    return toWallet(data)
+  }
+
+  const state = readStateToken(undefined)
+  return {
+    ...defaultWallet(),
+    ...state.wallet,
+    currency: "USD",
+  }
+}
+
+function normalizeGameSlug(value: unknown) {
+  return typeof value === "string" ? value.trim().slice(0, 80) : ""
+}
+
+function normalizeIdempotencyKey(value: unknown, fallbackPrefix: string) {
+  return typeof value === "string" && value.trim()
+    ? value.trim().slice(0, 160)
+    : `${fallbackPrefix}-${Date.now()}-${Math.random().toString(16).slice(2)}`
+}
+
+function toRpcWalletEntry(value: unknown): WalletEntryResult | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? toWalletEntryResult(value as Record<string, unknown>)
+    : null
+}
+
+function toRpcTableSessionResult(value: unknown): {
+  tableSession: MemberTableSession
+  walletEntry: WalletEntryResult | null
+  idempotent: boolean
+} {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Table session service returned an invalid response.")
+  }
+
+  const payload = value as Record<string, unknown>
+  const sessionPayload = payload.session
+
+  if (!sessionPayload || typeof sessionPayload !== "object" || Array.isArray(sessionPayload)) {
+    throw new Error("Table session service returned an invalid session.")
+  }
+
+  return {
+    tableSession: toTableSession(sessionPayload as Record<string, unknown>),
+    walletEntry: toRpcWalletEntry(payload.wallet_entry),
+    idempotent: payload.idempotent === true,
+  }
+}
+
+export async function readActiveTableSession(cookieStore: CookieStore, gameSlug: string, response?: NextResponse) {
+  const auth = await getAuthenticatedMember(cookieStore, response)
+
+  if (!auth) {
+    return null
+  }
+
+  if (auth.source === "supabase") {
+    if (!auth.supabase || !auth.session.userId) {
+      throw new Error("Supabase member session is missing a user id.")
+    }
+
+    const { data, error } = await auth.supabase
+      .from("member_table_sessions")
+      .select("*")
+      .eq("user_id", auth.session.userId)
+      .eq("game_slug", gameSlug)
+      .eq("status", "active")
+      .order("opened_at", { ascending: false })
+      .limit(1)
+      .maybeSingle()
+
+    if (error) {
+      throw new Error(error.message)
+    }
+
+    return data ? toTableSession(data) : null
+  }
+
+  const state = readStateToken(cookieStore.get(MEMBER_STATE_COOKIE)?.value)
+  return (state.tableSessions ?? []).find((session) => session.gameSlug === gameSlug && session.status === "active") ?? null
+}
+
+export async function openTableSession(
+  cookieStore: CookieStore,
+  response: NextResponse,
+  body: unknown,
+): Promise<TableSessionMutationResult | null> {
+  const auth = await getAuthenticatedMember(cookieStore, response)
+
+  if (!auth) {
+    return null
+  }
+
+  const patchBody = body && typeof body === "object" ? (body as Record<string, unknown>) : {}
+  const gameSlug = normalizeGameSlug(patchBody.gameSlug)
+  const buyInAmount = Math.min(1000000, Math.max(1, normalizeMoney(patchBody.buyInAmount, 100)))
+  const idempotencyKey = normalizeIdempotencyKey(patchBody.idempotencyKey, "table-session")
+
+  if (!gameSlug) {
+    throw new Error("Game slug is required.")
+  }
+
+  if (auth.source === "supabase") {
+    if (!auth.session.userId) {
+      throw new Error("Supabase member session is missing a user id.")
+    }
+
+    const serviceSupabase = createSupabaseServiceClient()
+    const { data, error } = await serviceSupabase.rpc("open_member_table_session", {
+      p_user_id: auth.session.userId,
+      p_game_slug: gameSlug,
+      p_buy_in_amount: buyInAmount,
+      p_idempotency_key: idempotencyKey,
+      p_metadata: normalizeRecord(patchBody.metadata),
+    })
+
+    if (error) {
+      throw new Error(error.message)
+    }
+
+    const result = toRpcTableSessionResult(data)
+    return {
+      ...result,
+      wallet: await readAuthenticatedWallet(auth),
+    }
+  }
+
+  const state = readStateToken(cookieStore.get(MEMBER_STATE_COOKIE)?.value)
+  const activeSession = (state.tableSessions ?? []).find((session) => session.gameSlug === gameSlug && session.status === "active")
+
+  if (activeSession) {
+    return {
+      tableSession: activeSession,
+      walletEntry: null,
+      wallet: {
+        ...defaultWallet(),
+        ...state.wallet,
+        currency: "USD",
+      },
+      idempotent: true,
+    }
+  }
+
+  const sessionId = randomUUID()
+  const walletEntry = applyLocalWalletEntry(auth, cookieStore, response, {
+    source: "table_buy_in",
+    amount: -buyInAmount,
+    referenceId: sessionId,
+    idempotencyKey: `table-buy-in:${idempotencyKey}`,
+    metadata: { gameSlug, tableSessionId: sessionId },
+  })
+  const createdAt = walletEntry.createdAt
+  const tableSession: MemberTableSession = {
+    id: sessionId,
+    gameSlug,
+    status: "active",
+    buyInAmount,
+    chipBalance: buyInAmount,
+    walletLedgerId: walletEntry.ledgerId,
+    cashOutLedgerId: null,
+    idempotencyKey,
+    metadata: normalizeRecord(patchBody.metadata),
+    openedAt: createdAt,
+    closedAt: null,
+    updatedAt: createdAt,
+  }
+  const nextWallet = {
+    ...defaultWallet(),
+    ...state.wallet,
+    balance: walletEntry.balanceAfter,
+    updatedAt: createdAt,
+    currency: "USD" as const,
+  }
+
+  writeLocalState(response, {
+    ...state,
+    wallet: nextWallet,
+    tableSessions: compactLocalTableSessions([tableSession, ...(state.tableSessions ?? [])]),
+  })
+
+  return {
+    tableSession,
+    walletEntry,
+    wallet: nextWallet,
+    idempotent: false,
+  }
+}
+
+export async function cashOutTableSession(
+  cookieStore: CookieStore,
+  response: NextResponse,
+  sessionId: string,
+  body: unknown,
+): Promise<TableSessionMutationResult | null> {
+  const auth = await getAuthenticatedMember(cookieStore, response)
+
+  if (!auth) {
+    return null
+  }
+
+  const patchBody = body && typeof body === "object" ? (body as Record<string, unknown>) : {}
+  const idempotencyKey = normalizeIdempotencyKey(patchBody.idempotencyKey, `table-cash-out-${sessionId}`)
+
+  if (auth.source === "supabase") {
+    if (!auth.session.userId) {
+      throw new Error("Supabase member session is missing a user id.")
+    }
+
+    const serviceSupabase = createSupabaseServiceClient()
+    const { data, error } = await serviceSupabase.rpc("cash_out_member_table_session", {
+      p_user_id: auth.session.userId,
+      p_session_id: sessionId,
+      p_idempotency_key: idempotencyKey,
+    })
+
+    if (error) {
+      throw new Error(error.message)
+    }
+
+    const result = toRpcTableSessionResult(data)
+    return {
+      ...result,
+      wallet: await readAuthenticatedWallet(auth),
+    }
+  }
+
+  const state = readStateToken(cookieStore.get(MEMBER_STATE_COOKIE)?.value)
+  const sessions = [...(state.tableSessions ?? [])]
+  const sessionIndex = sessions.findIndex((session) => session.id === sessionId)
+  const tableSession = sessionIndex >= 0 ? sessions[sessionIndex] : null
+
+  if (!tableSession) {
+    throw new Error("Table session was not found.")
+  }
+
+  if (tableSession.status !== "active") {
+    return {
+      tableSession,
+      walletEntry: null,
+      wallet: {
+        ...defaultWallet(),
+        ...state.wallet,
+        currency: "USD",
+      },
+      idempotent: true,
+    }
+  }
+
+  const walletEntry = applyLocalWalletEntry(auth, cookieStore, response, {
+    source: "table_cash_out",
+    amount: tableSession.chipBalance,
+    referenceId: tableSession.id,
+    idempotencyKey,
+    metadata: { gameSlug: tableSession.gameSlug, tableSessionId: tableSession.id },
+  })
+  const closedAt = walletEntry.createdAt
+  const nextSession: MemberTableSession = {
+    ...tableSession,
+    status: "cashed_out",
+    chipBalance: 0,
+    cashOutLedgerId: walletEntry.ledgerId,
+    closedAt,
+    updatedAt: closedAt,
+  }
+  sessions[sessionIndex] = nextSession
+  const nextWallet = {
+    ...defaultWallet(),
+    ...state.wallet,
+    balance: walletEntry.balanceAfter,
+    updatedAt: closedAt,
+    currency: "USD" as const,
+  }
+
+  writeLocalState(response, {
+    ...state,
+    wallet: nextWallet,
+    tableSessions: compactLocalTableSessions(sessions),
+  })
+
+  return {
+    tableSession: nextSession,
+    walletEntry,
+    wallet: nextWallet,
+    idempotent: false,
+  }
+}
+
+async function applySupabaseTableSessionDelta(auth: AuthenticatedMember, sessionId: string, delta: number) {
+  if (!auth.session.userId) {
+    throw new Error("Supabase member session is missing a user id.")
+  }
+
+  const serviceSupabase = createSupabaseServiceClient()
+  const { data, error } = await serviceSupabase.rpc("apply_member_table_session_delta", {
+    p_user_id: auth.session.userId,
+    p_session_id: sessionId,
+    p_delta: delta,
+  })
+
+  if (error) {
+    throw new Error(error.message)
+  }
+
+  if (!data || typeof data !== "object" || Array.isArray(data)) {
+    throw new Error("Table session service returned an invalid response.")
+  }
+
+  const payload = data as Record<string, unknown>
+  const sessionPayload = payload.session
+
+  if (!sessionPayload || typeof sessionPayload !== "object" || Array.isArray(sessionPayload)) {
+    throw new Error("Table session service returned an invalid session.")
+  }
+
+  return {
+    tableSession: toTableSession(sessionPayload as Record<string, unknown>),
+    chipBalanceBefore: normalizeMoney(payload.chip_balance_before),
+    chipBalanceAfter: normalizeMoney(payload.chip_balance_after),
   }
 }
 
@@ -393,27 +1138,78 @@ async function readSupabaseOverview(auth: AuthenticatedMember): Promise<MemberOv
     throw new Error("Supabase member session is missing a user id.")
   }
 
-  const [{ data: profileRow }, { data: settingsRow }, { data: walletRow }, { data: progressRows }, { data: eventRows }] =
-    await Promise.all([
-      supabase.from("profiles").select("id, display_name, avatar_url, created_at, updated_at").eq("id", userId).maybeSingle(),
-      supabase.from("member_settings").select("*").eq("user_id", userId).maybeSingle(),
-      supabase.from("member_wallets").select("*").eq("user_id", userId).maybeSingle(),
-      supabase
-        .from("member_game_progress")
-        .select("*")
-        .eq("user_id", userId)
-        .order("last_played_at", { ascending: false, nullsFirst: false })
-        .limit(8),
-      supabase.from("member_events").select("*").eq("user_id", userId).order("created_at", { ascending: false }).limit(8),
-    ])
+  const [
+    profileResult,
+    settingsResult,
+    walletResult,
+    progressResult,
+    eventResult,
+    ledgerResult,
+    roundResult,
+    adRewardResult,
+    purchaseResult,
+  ] = await Promise.all([
+    supabase.from("profiles").select("id, display_name, avatar_url, created_at, updated_at").eq("id", userId).maybeSingle(),
+    supabase.from("member_settings").select("*").eq("user_id", userId).maybeSingle(),
+    supabase.from("member_wallets").select("*").eq("user_id", userId).maybeSingle(),
+    supabase
+      .from("member_game_progress")
+      .select("*")
+      .eq("user_id", userId)
+      .order("last_played_at", { ascending: false, nullsFirst: false })
+      .limit(8),
+    supabase.from("member_events").select("*").eq("user_id", userId).order("created_at", { ascending: false }).limit(8),
+    supabase
+      .from("member_wallet_ledger")
+      .select("*")
+      .eq("user_id", userId)
+      .order("created_at", { ascending: false })
+      .limit(50),
+    supabase
+      .from("member_game_rounds")
+      .select("*")
+      .eq("user_id", userId)
+      .order("created_at", { ascending: false })
+      .limit(50),
+    supabase
+      .from("member_ad_rewards")
+      .select("*")
+      .eq("user_id", userId)
+      .order("created_at", { ascending: false })
+      .limit(8),
+    supabase.from("member_purchases").select("*").eq("user_id", userId).order("created_at", { ascending: false }).limit(8),
+  ])
+  const supabaseErrors = [
+    ["profiles", profileResult.error],
+    ["member_settings", settingsResult.error],
+    ["member_wallets", walletResult.error],
+    ["member_game_progress", progressResult.error],
+    ["member_events", eventResult.error],
+    ["member_wallet_ledger", ledgerResult.error],
+    ["member_game_rounds", roundResult.error],
+    ["member_ad_rewards", adRewardResult.error],
+    ["member_purchases", purchaseResult.error],
+  ].filter(([, error]) => error)
+
+  if (supabaseErrors.length > 0) {
+    throw new Error(
+      `Supabase member overview query failed: ${supabaseErrors
+        .map(([table, error]) => `${table}: ${formatSupabaseError(error)}`)
+        .join("; ")}`,
+    )
+  }
 
   return {
     session: auth.session,
-    profile: toProfile(auth.session, profileRow),
-    settings: toSettings(settingsRow),
-    wallet: toWallet(walletRow),
-    progress: Array.isArray(progressRows) ? progressRows.map((row) => toProgress(row)) : [],
-    recentEvents: Array.isArray(eventRows) ? eventRows.map((row) => toEvent(row)) : [],
+    profile: toProfile(auth.session, profileResult.data),
+    settings: toSettings(settingsResult.data),
+    wallet: toWallet(walletResult.data),
+    progress: Array.isArray(progressResult.data) ? progressResult.data.map((row) => toProgress(row)) : [],
+    recentEvents: Array.isArray(eventResult.data) ? eventResult.data.map((row) => toEvent(row)) : [],
+    walletLedger: Array.isArray(ledgerResult.data) ? ledgerResult.data.map((row) => toWalletLedgerEntry(row)) : [],
+    gameRounds: Array.isArray(roundResult.data) ? roundResult.data.map((row) => toGameRound(row)) : [],
+    adRewards: Array.isArray(adRewardResult.data) ? adRewardResult.data.map((row) => toAdReward(row)) : [],
+    purchases: Array.isArray(purchaseResult.data) ? purchaseResult.data.map((row) => toPurchase(row)) : [],
   }
 }
 
@@ -438,6 +1234,10 @@ function readLocalOverview(auth: AuthenticatedMember, cookieStore: CookieStore):
     },
     progress: state.progress ?? [],
     recentEvents: state.recentEvents ?? [],
+    walletLedger: state.walletLedger ?? [],
+    gameRounds: state.gameRounds ?? [],
+    adRewards: state.adRewards ?? [],
+    purchases: state.purchases ?? [],
   }
 }
 
@@ -566,6 +1366,109 @@ export async function updateMemberSettings(cookieStore: CookieStore, response: N
   return settings
 }
 
+async function findSupabaseRoundByIdempotencyKey(userId: string, idempotencyKey: string) {
+  const serviceSupabase = createSupabaseServiceClient()
+  const { data, error } = await serviceSupabase
+    .from("member_game_rounds")
+    .select("*")
+    .eq("user_id", userId)
+    .eq("idempotency_key", idempotencyKey)
+    .maybeSingle()
+
+  if (error) {
+    throw new Error(error.message)
+  }
+
+  return data ? toGameRound(data) : null
+}
+
+async function insertSupabaseGameRound({
+  userId,
+  gameSlug,
+  tableSessionId,
+  outcome,
+  delta,
+  totalStake,
+  chipBalanceBefore,
+  chipBalanceAfter,
+  summary,
+  betSnapshot,
+  resultSnapshot,
+  idempotencyKey,
+}: {
+  userId: string
+  gameSlug: string
+  tableSessionId?: string | null
+  outcome: ProgressOutcome
+  delta: number
+  totalStake: number
+  chipBalanceBefore?: number | null
+  chipBalanceAfter?: number | null
+  summary: string
+  betSnapshot: Record<string, unknown>
+  resultSnapshot: Record<string, unknown>
+  idempotencyKey: string | null
+}) {
+  const serviceSupabase = createSupabaseServiceClient()
+  const { data, error } = await serviceSupabase
+    .from("member_game_rounds")
+    .insert({
+      user_id: userId,
+      game_slug: gameSlug,
+      table_session_id: tableSessionId ?? null,
+      round_status: "settled",
+      total_stake: totalStake,
+      delta,
+      outcome,
+      chip_balance_before: chipBalanceBefore ?? null,
+      chip_balance_after: chipBalanceAfter ?? null,
+      result_summary: summary,
+      bet_snapshot: betSnapshot,
+      result_snapshot: resultSnapshot,
+      idempotency_key: idempotencyKey,
+    })
+    .select("*")
+    .single()
+
+  if (error) {
+    if (idempotencyKey && error.code === "23505") {
+      return findSupabaseRoundByIdempotencyKey(userId, idempotencyKey)
+    }
+
+    throw new Error(error.message)
+  }
+
+  return toGameRound(data)
+}
+
+export async function applyTestWalletTopUp(cookieStore: CookieStore, response: NextResponse, body: unknown) {
+  if (process.env.NODE_ENV === "production" && process.env.TAIHU_ENABLE_TEST_WALLET_TOPUP !== "true") {
+    throw new Error("Test wallet top-up is disabled.")
+  }
+
+  const patchBody = body && typeof body === "object" ? (body as Record<string, unknown>) : {}
+  const amount = Math.min(100000, Math.max(1, normalizeMoney(patchBody.amount, 1000)))
+  const idempotencyKey =
+    typeof patchBody.idempotencyKey === "string"
+      ? patchBody.idempotencyKey.slice(0, 160)
+      : `test-topup-${Date.now()}-${Math.random().toString(16).slice(2)}`
+  const walletEntry = await applyWalletEntry(cookieStore, response, {
+    source: "admin_adjustment",
+    amount,
+    idempotencyKey,
+    metadata: {
+      reason: "settings_test_topup",
+      testOnly: true,
+    },
+  })
+
+  if (!walletEntry) {
+    return null
+  }
+
+  return walletEntry
+}
+
 export async function recordGameProgress(cookieStore: CookieStore, response: NextResponse, body: unknown) {
   const auth = await getAuthenticatedMember(cookieStore, response)
 
@@ -581,9 +1484,14 @@ export async function recordGameProgress(cookieStore: CookieStore, response: Nex
     throw new Error("A game slug and valid outcome are required.")
   }
 
-  const delta = normalizeNumber(patchBody.delta, 0, -1000000, 1000000)
-  const bankroll = normalizeNumber(patchBody.bankroll, 25000, 0, 100000000)
+  const delta = Math.min(1000000, Math.max(-1000000, normalizeMoney(patchBody.delta)))
+  const clientBankroll = normalizeNumber(patchBody.bankroll, 25000, 0, 100000000)
+  const idempotencyKey = typeof patchBody.idempotencyKey === "string" ? patchBody.idempotencyKey.slice(0, 160) : null
+  const tableSessionId = typeof patchBody.tableSessionId === "string" ? patchBody.tableSessionId.slice(0, 80) : null
   const summary = typeof patchBody.summary === "string" ? patchBody.summary.slice(0, 280) : ""
+  const totalStake = normalizeNumber(patchBody.totalStake, Math.abs(delta), 0, 100000000)
+  const betSnapshot = normalizeRecord(patchBody.betSnapshot)
+  const resultSnapshot = normalizeRecord(patchBody.resultSnapshot)
   const playedAt = nowIso()
   const event: MemberEvent = {
     id: `${Date.now()}-${Math.random().toString(16).slice(2)}`,
@@ -600,13 +1508,139 @@ export async function recordGameProgress(cookieStore: CookieStore, response: Nex
       throw new Error("Supabase member session is missing a user id.")
     }
 
-    const { data: existing } = await auth.supabase
+    if (tableSessionId) {
+      const existingRound =
+        idempotencyKey ? await findSupabaseRoundByIdempotencyKey(userId, idempotencyKey) : null
+      const { data: existing, error: existingError } = await auth.supabase
+        .from("member_game_progress")
+        .select("*")
+        .eq("user_id", userId)
+        .eq("game_slug", gameSlug)
+        .maybeSingle()
+
+      if (existingError) {
+        throw new Error(existingError.message)
+      }
+
+      const current = existing ? toProgress(existing) : null
+
+      if (existingRound && current) {
+        return current
+      }
+
+      const tableResult = await applySupabaseTableSessionDelta(auth, tableSessionId, delta)
+      const bankroll = tableResult.chipBalanceAfter
+      const streak = outcome === "win" ? (current?.streak ?? 0) + 1 : outcome === "loss" ? 0 : current?.streak ?? 0
+      const progress = {
+        user_id: userId,
+        game_slug: gameSlug,
+        plays: (current?.plays ?? 0) + 1,
+        wins: (current?.wins ?? 0) + (outcome === "win" ? 1 : 0),
+        losses: (current?.losses ?? 0) + (outcome === "loss" ? 1 : 0),
+        streak,
+        best_streak: Math.max(current?.bestStreak ?? 0, streak),
+        bankroll,
+        last_result: outcome,
+        last_delta: delta,
+        last_summary: summary,
+        last_played_at: playedAt,
+      }
+      const { data, error } = await auth.supabase.from("member_game_progress").upsert(progress).select("*").single()
+
+      if (error) {
+        throw new Error(error.message)
+      }
+
+      await insertSupabaseGameRound({
+        userId,
+        gameSlug,
+        tableSessionId,
+        outcome,
+        delta,
+        totalStake,
+        chipBalanceBefore: tableResult.chipBalanceBefore,
+        chipBalanceAfter: tableResult.chipBalanceAfter,
+        summary,
+        betSnapshot,
+        resultSnapshot: {
+          ...resultSnapshot,
+          tableSessionId,
+          chipBalanceBefore: tableResult.chipBalanceBefore,
+          chipBalanceAfter: tableResult.chipBalanceAfter,
+        },
+        idempotencyKey,
+      })
+
+      const { error: eventError } = await auth.supabase
+        .from("member_events")
+        .insert({
+          user_id: userId,
+          kind: event.kind,
+          title: event.title,
+          detail: event.detail,
+        })
+
+      if (eventError) {
+        throw new Error(eventError.message)
+      }
+
+      return toProgress(data)
+    }
+
+    const walletEntry = await applyAuthenticatedWalletEntry(auth, cookieStore, response, {
+      source: "game_round",
+      amount: delta,
+      idempotencyKey,
+      metadata: {
+        gameSlug,
+        outcome,
+        summary,
+        totalStake,
+        betSnapshot,
+        resultSnapshot,
+        clientBankroll,
+      },
+    })
+    const bankroll = walletEntry.balanceAfter
+    const existingRound =
+      idempotencyKey ? await findSupabaseRoundByIdempotencyKey(userId, idempotencyKey) : null
+
+    const { data: existing, error: existingError } = await auth.supabase
       .from("member_game_progress")
       .select("*")
       .eq("user_id", userId)
       .eq("game_slug", gameSlug)
       .maybeSingle()
+
+    if (existingError) {
+      throw new Error(existingError.message)
+    }
+
     const current = existing ? toProgress(existing) : null
+
+    if (walletEntry.idempotent && current) {
+      if (!existingRound) {
+        await insertSupabaseGameRound({
+          userId,
+          gameSlug,
+          outcome,
+          delta,
+          totalStake,
+          summary,
+          betSnapshot,
+          resultSnapshot: {
+            ...resultSnapshot,
+            walletLedgerId: walletEntry.ledgerId,
+            balanceBefore: walletEntry.balanceBefore,
+            balanceAfter: walletEntry.balanceAfter,
+          },
+          idempotencyKey,
+        })
+      }
+
+      return current
+    }
+
     const streak = outcome === "win" ? (current?.streak ?? 0) + 1 : outcome === "loss" ? 0 : current?.streak ?? 0
     const progress = {
       user_id: userId,
@@ -628,35 +1662,191 @@ export async function recordGameProgress(cookieStore: CookieStore, response: Nex
       throw new Error(error.message)
     }
 
-    const [walletResult, eventResult] = await Promise.all([
-      auth.supabase.from("member_wallets").upsert({
-        user_id: userId,
-        currency: "USD",
-        balance: bankroll,
-      }),
-      auth.supabase.from("member_events").insert({
+    await insertSupabaseGameRound({
+      userId,
+      gameSlug,
+      outcome,
+      delta,
+      totalStake,
+      summary,
+      betSnapshot,
+      resultSnapshot: {
+        ...resultSnapshot,
+        walletLedgerId: walletEntry.ledgerId,
+        balanceBefore: walletEntry.balanceBefore,
+        balanceAfter: walletEntry.balanceAfter,
+      },
+      idempotencyKey,
+    })
+
+    const { error: eventError } = await auth.supabase
+      .from("member_events")
+      .insert({
         user_id: userId,
         kind: event.kind,
         title: event.title,
         detail: event.detail,
-      }),
-    ])
+      })
 
-    if (walletResult.error) {
-      throw new Error(walletResult.error.message)
-    }
-
-    if (eventResult.error) {
-      throw new Error(eventResult.error.message)
+    if (eventError) {
+      throw new Error(eventError.message)
     }
 
     return toProgress(data)
   }
 
+  if (tableSessionId) {
+    const state = readStateToken(cookieStore.get(MEMBER_STATE_COOKIE)?.value)
+    const existingRound =
+      idempotencyKey && state.gameRounds
+        ? state.gameRounds.find((round) => round.idempotencyKey === idempotencyKey)
+        : undefined
+    const progress = [...(state.progress ?? [])]
+    const existingIndex = progress.findIndex((item) => item.gameSlug === gameSlug)
+    const current = existingIndex >= 0 ? progress[existingIndex] : undefined
+
+    if (existingRound && current) {
+      return current
+    }
+
+    const sessions = [...(state.tableSessions ?? [])]
+    const sessionIndex = sessions.findIndex((session) => session.id === tableSessionId && session.status === "active")
+    const tableSession = sessionIndex >= 0 ? sessions[sessionIndex] : null
+
+    if (!tableSession) {
+      throw new Error("Active table session was not found.")
+    }
+
+    const chipBalanceBefore = tableSession.chipBalance
+    const chipBalanceAfter = Math.round((chipBalanceBefore + delta) * 100) / 100
+
+    if (chipBalanceAfter < 0) {
+      throw new Error("Insufficient table chips.")
+    }
+
+    const nextSession: MemberTableSession = {
+      ...tableSession,
+      chipBalance: chipBalanceAfter,
+      updatedAt: playedAt,
+    }
+    sessions[sessionIndex] = nextSession
+    const streak = outcome === "win" ? (current?.streak ?? 0) + 1 : outcome === "loss" ? 0 : current?.streak ?? 0
+    const nextProgress: MemberGameProgress = {
+      gameSlug,
+      plays: (current?.plays ?? 0) + 1,
+      wins: (current?.wins ?? 0) + (outcome === "win" ? 1 : 0),
+      losses: (current?.losses ?? 0) + (outcome === "loss" ? 1 : 0),
+      streak,
+      bestStreak: Math.max(current?.bestStreak ?? 0, streak),
+      bankroll: chipBalanceAfter,
+      lastResult: outcome,
+      lastDelta: delta,
+      lastSummary: summary,
+      lastPlayedAt: playedAt,
+    }
+
+    if (existingIndex >= 0) {
+      progress[existingIndex] = nextProgress
+    } else {
+      progress.unshift(nextProgress)
+    }
+
+    writeLocalState(response, {
+      ...state,
+      progress: compactLocalProgress(progress),
+      recentEvents: compactLocalEvents([event, ...(state.recentEvents ?? [])]),
+      tableSessions: compactLocalTableSessions(sessions),
+      gameRounds: compactLocalGameRounds([
+        {
+          id: `${playedAt}-${Math.random().toString(16).slice(2)}`,
+          gameSlug,
+          tableSessionId,
+          roundStatus: "settled",
+          totalStake,
+          delta,
+          outcome,
+          chipBalanceBefore,
+          chipBalanceAfter,
+          resultSummary: summary,
+          betSnapshot,
+          resultSnapshot: {
+            ...resultSnapshot,
+            tableSessionId,
+            chipBalanceBefore,
+            chipBalanceAfter,
+          },
+          idempotencyKey,
+          createdAt: playedAt,
+        },
+        ...(state.gameRounds ?? []),
+      ]),
+    })
+
+    return nextProgress
+  }
+
+  const walletEntry = await applyAuthenticatedWalletEntry(auth, cookieStore, response, {
+    source: "game_round",
+    amount: delta,
+    idempotencyKey,
+    metadata: {
+      gameSlug,
+      outcome,
+      summary,
+      totalStake,
+      betSnapshot,
+      resultSnapshot,
+      clientBankroll,
+    },
+  })
   const state = readStateToken(cookieStore.get(MEMBER_STATE_COOKIE)?.value)
+  const existingRound =
+    idempotencyKey && state.gameRounds
+      ? state.gameRounds.find((round) => round.idempotencyKey === idempotencyKey)
+      : undefined
   const progress = [...(state.progress ?? [])]
   const existingIndex = progress.findIndex((item) => item.gameSlug === gameSlug)
   const current = existingIndex >= 0 ? progress[existingIndex] : undefined
+
+  if (walletEntry.idempotent && current) {
+    if (!existingRound) {
+      writeLocalState(response, {
+        ...state,
+        wallet: {
+          ...(state.wallet ?? defaultWallet()),
+          balance: walletEntry.balanceAfter,
+          updatedAt: walletEntry.createdAt,
+        },
+        gameRounds: compactLocalGameRounds([
+          {
+            id: `${playedAt}-${Math.random().toString(16).slice(2)}`,
+            gameSlug,
+            tableSessionId: null,
+            roundStatus: "settled",
+            totalStake,
+            delta,
+            outcome,
+            chipBalanceBefore: null,
+            chipBalanceAfter: null,
+            resultSummary: summary,
+            betSnapshot,
+            resultSnapshot: {
+              ...resultSnapshot,
+              walletLedgerId: walletEntry.ledgerId,
+              balanceBefore: walletEntry.balanceBefore,
+              balanceAfter: walletEntry.balanceAfter,
+            },
+            idempotencyKey,
+            createdAt: playedAt,
+          },
+          ...(state.gameRounds ?? []),
+        ]),
+      })
+    }
+
+    return current
+  }
+
   const streak = outcome === "win" ? (current?.streak ?? 0) + 1 : outcome === "loss" ? 0 : current?.streak ?? 0
   const nextProgress: MemberGameProgress = {
     gameSlug,
@@ -665,7 +1855,7 @@ export async function recordGameProgress(cookieStore: CookieStore, response: Nex
     losses: (current?.losses ?? 0) + (outcome === "loss" ? 1 : 0),
     streak,
     bestStreak: Math.max(current?.bestStreak ?? 0, streak),
-    bankroll,
+    bankroll: walletEntry.balanceAfter,
     lastResult: outcome,
     lastDelta: delta,
     lastSummary: summary,
@@ -681,13 +1871,36 @@ export async function recordGameProgress(cookieStore: CookieStore, response: Nex
   writeLocalState(response, {
     ...state,
     wallet: {
-      ...defaultWallet(),
-      ...state.wallet,
-      balance: bankroll,
-      updatedAt: playedAt,
+      ...(state.wallet ?? defaultWallet()),
+      balance: walletEntry.balanceAfter,
+      updatedAt: walletEntry.createdAt,
     },
     progress: compactLocalProgress(progress),
     recentEvents: compactLocalEvents([event, ...(state.recentEvents ?? [])]),
+    gameRounds: compactLocalGameRounds([
+      {
+        id: `${playedAt}-${Math.random().toString(16).slice(2)}`,
+        gameSlug,
+        tableSessionId: null,
+        roundStatus: "settled",
+        totalStake,
+        delta,
+        outcome,
+        chipBalanceBefore: null,
+        chipBalanceAfter: null,
+        resultSummary: summary,
+        betSnapshot,
+        resultSnapshot: {
+          ...resultSnapshot,
+          walletLedgerId: walletEntry.ledgerId,
+          balanceBefore: walletEntry.balanceBefore,
+          balanceAfter: walletEntry.balanceAfter,
+        },
+        idempotencyKey,
+        createdAt: playedAt,
+      },
+      ...(state.gameRounds ?? []),
+    ]),
   })
 
   return nextProgress

--- a/lib/server-auth.ts
+++ b/lib/server-auth.ts
@@ -3,6 +3,7 @@ import "server-only"
 import { createHmac, timingSafeEqual } from "node:crypto"
 
 import { createServerClient } from "@supabase/ssr"
+import { createClient } from "@supabase/supabase-js"
 import type { cookies } from "next/headers"
 import type { NextResponse } from "next/server"
 import type { User } from "@supabase/supabase-js"
@@ -37,6 +38,10 @@ function getSupabaseUrl() {
 
 function getSupabaseKey() {
   return process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY ?? process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+}
+
+function getSupabaseServiceRoleKey() {
+  return process.env.SUPABASE_SERVICE_ROLE_KEY
 }
 
 function getDisplayName(account: string, displayName?: string) {
@@ -78,7 +83,7 @@ function getAuthUsers() {
 }
 
 export function getLocalDemoCredentials() {
-  if (process.env.NODE_ENV === "production" || isSupabaseAuthConfigured()) {
+  if (process.env.NODE_ENV === "production") {
     return null
   }
 
@@ -161,6 +166,23 @@ export function createSupabaseAuthClient(cookieStore: CookieStore, response?: Ne
           })
         }
       },
+    },
+  })
+}
+
+export function createSupabaseServiceClient() {
+  const supabaseUrl = getSupabaseUrl()
+  const serviceRoleKey = getSupabaseServiceRoleKey()
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    throw new Error("SUPABASE_SERVICE_ROLE_KEY is required for server-side wallet mutations.")
+  }
+
+  return createClient(supabaseUrl, serviceRoleKey, {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+      detectSessionInUrl: false,
     },
   })
 }

--- a/lib/table-session-client.ts
+++ b/lib/table-session-client.ts
@@ -1,0 +1,71 @@
+import { type MemberTableSession } from "@/lib/member-data"
+
+interface TableSessionMutationPayload {
+  error?: string
+  tableSession?: MemberTableSession
+  wallet?: {
+    balance?: unknown
+  }
+}
+
+export interface TableSessionMutationResult {
+  tableSession: MemberTableSession
+  walletBalance: number | null
+}
+
+function parseTableSessionPayload(payload: TableSessionMutationPayload | null) {
+  if (!payload?.tableSession) {
+    return null
+  }
+
+  return {
+    tableSession: payload.tableSession,
+    walletBalance: typeof payload.wallet?.balance === "number" ? payload.wallet.balance : null,
+  } satisfies TableSessionMutationResult
+}
+
+export async function openClientTableSession(
+  gameSlug: string,
+  buyInAmount: number,
+  idempotencyPrefix: string,
+) {
+  const response = await fetch("/api/member/table-sessions", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      gameSlug,
+      buyInAmount,
+      idempotencyKey: `${idempotencyPrefix}-${gameSlug}-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+    }),
+  })
+  const payload = (await response.json().catch(() => null)) as TableSessionMutationPayload | null
+  const parsed = parseTableSessionPayload(payload)
+
+  if (!response.ok || !parsed) {
+    throw new Error(payload?.error ?? "Unable to buy in.")
+  }
+
+  return parsed
+}
+
+export async function cashOutClientTableSession(sessionId: string, idempotencyPrefix: string) {
+  const response = await fetch(`/api/member/table-sessions/${sessionId}/cash-out`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      idempotencyKey: `${idempotencyPrefix}-${sessionId}-${Date.now()}`,
+    }),
+  })
+  const payload = (await response.json().catch(() => null)) as TableSessionMutationPayload | null
+  const parsed = parseTableSessionPayload(payload)
+
+  if (!response.ok || !parsed) {
+    throw new Error(payload?.error ?? "Unable to cash out.")
+  }
+
+  return parsed
+}

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "postcss": "^8.5",
+    "supabase": "^2.98.0",
     "tailwindcss": "^4.2.0",
     "tw-animate-css": "1.3.3",
     "typescript": "5.7.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,6 +177,9 @@ importers:
       postcss:
         specifier: ^8.5
         version: 8.5.6
+      supabase:
+        specifier: ^2.98.0
+        version: 2.98.0
       tailwindcss:
         specifier: ^4.2.0
         version: 4.2.0
@@ -375,6 +378,10 @@ packages:
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [win32]
+
+  '@isaacs/fs-minipass@4.0.1':
+    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
+    engines: {node: '>=18.0.0'}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -1297,6 +1304,10 @@ packages:
       vue-router:
         optional: true
 
+  agent-base@9.0.0:
+    resolution: {integrity: sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==}
+    engines: {node: '>= 20'}
+
   aria-hidden@1.2.6:
     resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
     engines: {node: '>=10'}
@@ -1312,6 +1323,10 @@ packages:
     resolution: {integrity: sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==}
     hasBin: true
 
+  bin-links@6.0.0:
+    resolution: {integrity: sha512-X4CiKlcV2GjnCMwnKAfbVWpHa++65th9TuzAEYtZoATiOE2DQKhSp4CJlyLoTqdhBKlXjpXjCTYPNNFS33Fi6w==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   browserslist@4.28.1:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -1319,6 +1334,10 @@ packages:
 
   caniuse-lite@1.0.30001769:
     resolution: {integrity: sha512-BCfFL1sHijQlBGWBMuJyhZUhzo7wer5sVj9hqekB/7xn0Ypy+pER/edCYQm4exbXj4WiySGp40P8UuTh6w1srg==}
+
+  chownr@3.0.0:
+    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
+    engines: {node: '>=18'}
 
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
@@ -1329,6 +1348,10 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
+
+  cmd-shim@8.0.0:
+    resolution: {integrity: sha512-Jk/BK6NCapZ58BKUxlSI+ouKRbjH1NLZCgJkYoab+vEHUY3f6OzpNBN9u7HFSv9J6TRDGs4PLOHezoKGaFRSCA==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   cmdk@1.1.1:
     resolution: {integrity: sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==}
@@ -1387,11 +1410,24 @@ packages:
     resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
     engines: {node: '>=12'}
 
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
+
   date-fns-jalali@4.1.0-0:
     resolution: {integrity: sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==}
 
   date-fns@4.1.0:
     resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
 
   decimal.js-light@2.5.1:
     resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
@@ -1437,6 +1473,14 @@ packages:
     resolution: {integrity: sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==}
     engines: {node: '>=6.0.0'}
 
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
 
@@ -1446,6 +1490,10 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  https-proxy-agent@9.0.0:
+    resolution: {integrity: sha512-/MVmHp58WkOypgFhCLk4fzpPcFQvTJ/e6LBI7irpIO2HfxUbpmYoHF+KzipzJpxxzJu7aJNWQ0xojJ/dzV2G5g==}
+    engines: {node: '>= 20'}
 
   iceberg-js@0.8.1:
     resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
@@ -1557,6 +1605,17 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minizlib@3.1.0:
+    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
+    engines: {node: '>= 18'}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -1589,8 +1648,21 @@ packages:
       sass:
         optional: true
 
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
+
+  npm-normalize-package-bin@5.0.0:
+    resolution: {integrity: sha512-CJi3OS4JLsNMmr2u07OJlhcrPxCeOeP/4xq67aWNai6TNWWbTrlNDgl8NcFKVlcBKp18GPj+EzbNIgrBfZhsag==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -1609,6 +1681,10 @@ packages:
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  proc-log@6.1.0:
+    resolution: {integrity: sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==}
+    engines: {node: ^20.17.0 || >=22.9.0}
 
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
@@ -1688,6 +1764,10 @@ packages:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
 
+  read-cmd-shim@6.0.0:
+    resolution: {integrity: sha512-1zM5HuOfagXCBWMN83fuFI/x+T/UhZ7k+KIzhrHXcQoeX5+7gmaDYjELQHmmzIodumBHeByBJT4QYS7ufAgs7A==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   recharts-scale@0.4.5:
     resolution: {integrity: sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==}
 
@@ -1709,6 +1789,10 @@ packages:
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
 
   sonner@1.7.4:
     resolution: {integrity: sha512-DIS8z4PfJRbIyfVFDVnK9rO3eYDtse4Omcm6bt0oEr5/jtLgysmjuBl1frJ9E/EQZrFmKx2A8m/s5s9CRXIzhw==}
@@ -1733,6 +1817,11 @@ packages:
       babel-plugin-macros:
         optional: true
 
+  supabase@2.98.0:
+    resolution: {integrity: sha512-1r56wzoi6SFj+i0XHqF9rSLrjaBSrs+t6xUWn3I+UVnO9nb5ITkmaLEeGgjf7naiBUDf9rtqyRoI+5hTrezZNg==}
+    engines: {npm: '>=8'}
+    hasBin: true
+
   tailwind-merge@3.4.0:
     resolution: {integrity: sha512-uSaO4gnW+b3Y2aWoWfFpX62vn2sR3skfhbjsEnaBI81WD1wBLlHZe5sWf0AqjksNdYTbGBEd0UasQMT3SNV15g==}
 
@@ -1742,6 +1831,10 @@ packages:
   tapable@2.3.0:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
+
+  tar@7.5.13:
+    resolution: {integrity: sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==}
+    engines: {node: '>=18'}
 
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
@@ -1800,6 +1893,14 @@ packages:
   victory-vendor@36.9.2:
     resolution: {integrity: sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==}
 
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
+
+  write-file-atomic@7.0.1:
+    resolution: {integrity: sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+
   ws@8.20.0:
     resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
     engines: {node: '>=10.0.0'}
@@ -1811,6 +1912,10 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  yallist@5.0.0:
+    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
+    engines: {node: '>=18'}
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -1945,6 +2050,10 @@ snapshots:
 
   '@img/sharp-win32-x64@0.34.5':
     optional: true
+
+  '@isaacs/fs-minipass@4.0.1':
+    dependencies:
+      minipass: 7.1.3
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -2849,6 +2958,8 @@ snapshots:
       next: 16.2.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
 
+  agent-base@9.0.0: {}
+
   aria-hidden@1.2.6:
     dependencies:
       tslib: 2.8.1
@@ -2864,6 +2975,14 @@ snapshots:
 
   baseline-browser-mapping@2.9.19: {}
 
+  bin-links@6.0.0:
+    dependencies:
+      cmd-shim: 8.0.0
+      npm-normalize-package-bin: 5.0.0
+      proc-log: 6.1.0
+      read-cmd-shim: 6.0.0
+      write-file-atomic: 7.0.1
+
   browserslist@4.28.1:
     dependencies:
       baseline-browser-mapping: 2.9.19
@@ -2874,6 +2993,8 @@ snapshots:
 
   caniuse-lite@1.0.30001769: {}
 
+  chownr@3.0.0: {}
+
   class-variance-authority@0.7.1:
     dependencies:
       clsx: 2.1.1
@@ -2881,6 +3002,8 @@ snapshots:
   client-only@0.0.1: {}
 
   clsx@2.1.1: {}
+
+  cmd-shim@8.0.0: {}
 
   cmdk@1.1.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
@@ -2936,9 +3059,15 @@ snapshots:
 
   d3-timer@3.0.1: {}
 
+  data-uri-to-buffer@4.0.1: {}
+
   date-fns-jalali@4.1.0-0: {}
 
   date-fns@4.1.0: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
 
   decimal.js-light@2.5.1: {}
 
@@ -2976,11 +3105,27 @@ snapshots:
 
   fast-equals@5.4.0: {}
 
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
+
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
+
   fraction.js@5.3.4: {}
 
   get-nonce@1.0.1: {}
 
   graceful-fs@4.2.11: {}
+
+  https-proxy-agent@9.0.0:
+    dependencies:
+      agent-base: 9.0.0
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   iceberg-js@0.8.1: {}
 
@@ -3058,6 +3203,14 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  minipass@7.1.3: {}
+
+  minizlib@3.1.0:
+    dependencies:
+      minipass: 7.1.3
+
+  ms@2.1.3: {}
+
   nanoid@3.3.11: {}
 
   next-themes@0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
@@ -3089,7 +3242,17 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
+  node-domexception@1.0.0: {}
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
+
   node-releases@2.0.27: {}
+
+  npm-normalize-package-bin@5.0.0: {}
 
   object-assign@4.1.1: {}
 
@@ -3108,6 +3271,8 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  proc-log@6.1.0: {}
 
   prop-types@15.8.1:
     dependencies:
@@ -3186,6 +3351,8 @@ snapshots:
 
   react@19.2.4: {}
 
+  read-cmd-shim@6.0.0: {}
+
   recharts-scale@0.4.5:
     dependencies:
       decimal.js-light: 2.5.1
@@ -3240,6 +3407,8 @@ snapshots:
       '@img/sharp-win32-x64': 0.34.5
     optional: true
 
+  signal-exit@4.1.0: {}
+
   sonner@1.7.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       react: 19.2.4
@@ -3252,11 +3421,28 @@ snapshots:
       client-only: 0.0.1
       react: 19.2.4
 
+  supabase@2.98.0:
+    dependencies:
+      bin-links: 6.0.0
+      https-proxy-agent: 9.0.0
+      node-fetch: 3.3.2
+      tar: 7.5.13
+    transitivePeerDependencies:
+      - supports-color
+
   tailwind-merge@3.4.0: {}
 
   tailwindcss@4.2.0: {}
 
   tapable@2.3.0: {}
+
+  tar@7.5.13:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.3
+      minizlib: 3.1.0
+      yallist: 5.0.0
 
   tiny-invariant@1.3.3: {}
 
@@ -3319,6 +3505,14 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
+  web-streams-polyfill@3.3.3: {}
+
+  write-file-atomic@7.0.1:
+    dependencies:
+      signal-exit: 4.1.0
+
   ws@8.20.0: {}
+
+  yallist@5.0.0: {}
 
   zod@3.25.76: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+allowBuilds:
+  sharp: true
+  supabase: true

--- a/supabase/migrations/20260502145843_member_wallet_service.sql
+++ b/supabase/migrations/20260502145843_member_wallet_service.sql
@@ -1,0 +1,142 @@
+create or replace function public.apply_member_wallet_entry(
+  p_user_id uuid,
+  p_source text,
+  p_amount numeric,
+  p_reference_id uuid default null,
+  p_idempotency_key text default null,
+  p_metadata jsonb default '{}'::jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  member_id uuid := p_user_id;
+  existing_entry public.member_wallet_ledger%rowtype;
+  current_balance numeric(14, 2);
+  next_balance numeric(14, 2);
+  ledger_entry public.member_wallet_ledger%rowtype;
+begin
+  if member_id is null then
+    raise exception 'Wallet user id is required.' using errcode = '22004';
+  end if;
+
+  if p_source not in ('game_round', 'ad_reward', 'purchase', 'admin_adjustment', 'system') then
+    raise exception 'Unsupported wallet source: %', p_source using errcode = '22023';
+  end if;
+
+  if p_amount is null then
+    raise exception 'Wallet amount is required.' using errcode = '22004';
+  end if;
+
+  if p_idempotency_key is not null then
+    select *
+    into existing_entry
+    from public.member_wallet_ledger
+    where member_wallet_ledger.idempotency_key = p_idempotency_key
+      and member_wallet_ledger.user_id = member_id
+    limit 1;
+
+    if found then
+      return jsonb_build_object(
+        'ledger_id', existing_entry.id,
+        'balance_before', existing_entry.balance_before,
+        'balance_after', existing_entry.balance_after,
+        'amount', existing_entry.amount,
+        'currency', existing_entry.currency,
+        'idempotent', true,
+        'created_at', existing_entry.created_at
+      );
+    end if;
+  end if;
+
+  insert into public.member_wallets (user_id)
+  values (member_id)
+  on conflict (user_id) do nothing;
+
+  select balance
+  into current_balance
+  from public.member_wallets
+  where user_id = member_id
+  for update;
+
+  if current_balance is null then
+    raise exception 'Member wallet is unavailable.' using errcode = 'P0002';
+  end if;
+
+  next_balance := round(current_balance + p_amount, 2);
+
+  if next_balance < 0 then
+    raise exception 'Insufficient wallet balance.' using errcode = 'P0001';
+  end if;
+
+  insert into public.member_wallet_ledger (
+    user_id,
+    source,
+    amount,
+    balance_before,
+    balance_after,
+    reference_id,
+    idempotency_key,
+    metadata
+  )
+  values (
+    member_id,
+    p_source,
+    round(p_amount, 2),
+    current_balance,
+    next_balance,
+    p_reference_id,
+    p_idempotency_key,
+    coalesce(p_metadata, '{}'::jsonb)
+  )
+  returning * into ledger_entry;
+
+  update public.member_wallets
+  set balance = next_balance,
+      updated_at = timezone('utc', now())
+  where user_id = member_id;
+
+  return jsonb_build_object(
+    'ledger_id', ledger_entry.id,
+    'balance_before', ledger_entry.balance_before,
+    'balance_after', ledger_entry.balance_after,
+    'amount', ledger_entry.amount,
+    'currency', ledger_entry.currency,
+    'idempotent', false,
+    'created_at', ledger_entry.created_at
+  );
+exception
+  when unique_violation then
+    if p_idempotency_key is null then
+      raise;
+    end if;
+
+    select *
+    into existing_entry
+    from public.member_wallet_ledger
+    where member_wallet_ledger.idempotency_key = p_idempotency_key
+      and member_wallet_ledger.user_id = member_id
+    limit 1;
+
+    if not found then
+      raise;
+    end if;
+
+    return jsonb_build_object(
+      'ledger_id', existing_entry.id,
+      'balance_before', existing_entry.balance_before,
+      'balance_after', existing_entry.balance_after,
+      'amount', existing_entry.amount,
+      'currency', existing_entry.currency,
+      'idempotent', true,
+      'created_at', existing_entry.created_at
+    );
+end;
+$$;
+
+revoke execute on function public.apply_member_wallet_entry(uuid, text, numeric, uuid, text, jsonb) from public;
+revoke execute on function public.apply_member_wallet_entry(uuid, text, numeric, uuid, text, jsonb) from anon;
+revoke execute on function public.apply_member_wallet_entry(uuid, text, numeric, uuid, text, jsonb) from authenticated;
+grant execute on function public.apply_member_wallet_entry(uuid, text, numeric, uuid, text, jsonb) to service_role;

--- a/supabase/migrations/20260502150312_member_api_grants.sql
+++ b/supabase/migrations/20260502150312_member_api_grants.sql
@@ -1,0 +1,20 @@
+grant usage on schema public to authenticated;
+
+grant select on table public.profiles to authenticated;
+grant insert, update on table public.profiles to authenticated;
+
+grant select on table public.member_settings to authenticated;
+grant insert, update on table public.member_settings to authenticated;
+
+grant select on table public.member_wallets to authenticated;
+
+grant select on table public.member_game_progress to authenticated;
+grant insert, update on table public.member_game_progress to authenticated;
+
+grant select on table public.member_events to authenticated;
+grant insert on table public.member_events to authenticated;
+
+grant select on table public.member_wallet_ledger to authenticated;
+grant select on table public.member_game_rounds to authenticated;
+grant select on table public.member_ad_rewards to authenticated;
+grant select on table public.member_purchases to authenticated;

--- a/supabase/migrations/20260502150554_restrict_wallet_rpc_to_service_role.sql
+++ b/supabase/migrations/20260502150554_restrict_wallet_rpc_to_service_role.sql
@@ -1,0 +1,144 @@
+create or replace function public.apply_member_wallet_entry(
+  p_user_id uuid,
+  p_source text,
+  p_amount numeric,
+  p_reference_id uuid default null,
+  p_idempotency_key text default null,
+  p_metadata jsonb default '{}'::jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  member_id uuid := p_user_id;
+  existing_entry public.member_wallet_ledger%rowtype;
+  current_balance numeric(14, 2);
+  next_balance numeric(14, 2);
+  ledger_entry public.member_wallet_ledger%rowtype;
+begin
+  if member_id is null then
+    raise exception 'Wallet user id is required.' using errcode = '22004';
+  end if;
+
+  if p_source not in ('game_round', 'ad_reward', 'purchase', 'admin_adjustment', 'system') then
+    raise exception 'Unsupported wallet source: %', p_source using errcode = '22023';
+  end if;
+
+  if p_amount is null then
+    raise exception 'Wallet amount is required.' using errcode = '22004';
+  end if;
+
+  if p_idempotency_key is not null then
+    select *
+    into existing_entry
+    from public.member_wallet_ledger
+    where member_wallet_ledger.idempotency_key = p_idempotency_key
+      and member_wallet_ledger.user_id = member_id
+    limit 1;
+
+    if found then
+      return jsonb_build_object(
+        'ledger_id', existing_entry.id,
+        'balance_before', existing_entry.balance_before,
+        'balance_after', existing_entry.balance_after,
+        'amount', existing_entry.amount,
+        'currency', existing_entry.currency,
+        'idempotent', true,
+        'created_at', existing_entry.created_at
+      );
+    end if;
+  end if;
+
+  insert into public.member_wallets (user_id)
+  values (member_id)
+  on conflict (user_id) do nothing;
+
+  select balance
+  into current_balance
+  from public.member_wallets
+  where user_id = member_id
+  for update;
+
+  if current_balance is null then
+    raise exception 'Member wallet is unavailable.' using errcode = 'P0002';
+  end if;
+
+  next_balance := round(current_balance + p_amount, 2);
+
+  if next_balance < 0 then
+    raise exception 'Insufficient wallet balance.' using errcode = 'P0001';
+  end if;
+
+  insert into public.member_wallet_ledger (
+    user_id,
+    source,
+    amount,
+    balance_before,
+    balance_after,
+    reference_id,
+    idempotency_key,
+    metadata
+  )
+  values (
+    member_id,
+    p_source,
+    round(p_amount, 2),
+    current_balance,
+    next_balance,
+    p_reference_id,
+    p_idempotency_key,
+    coalesce(p_metadata, '{}'::jsonb)
+  )
+  returning * into ledger_entry;
+
+  update public.member_wallets
+  set balance = next_balance,
+      updated_at = timezone('utc', now())
+  where user_id = member_id;
+
+  return jsonb_build_object(
+    'ledger_id', ledger_entry.id,
+    'balance_before', ledger_entry.balance_before,
+    'balance_after', ledger_entry.balance_after,
+    'amount', ledger_entry.amount,
+    'currency', ledger_entry.currency,
+    'idempotent', false,
+    'created_at', ledger_entry.created_at
+  );
+exception
+  when unique_violation then
+    if p_idempotency_key is null then
+      raise;
+    end if;
+
+    select *
+    into existing_entry
+    from public.member_wallet_ledger
+    where member_wallet_ledger.idempotency_key = p_idempotency_key
+      and member_wallet_ledger.user_id = member_id
+    limit 1;
+
+    if not found then
+      raise;
+    end if;
+
+    return jsonb_build_object(
+      'ledger_id', existing_entry.id,
+      'balance_before', existing_entry.balance_before,
+      'balance_after', existing_entry.balance_after,
+      'amount', existing_entry.amount,
+      'currency', existing_entry.currency,
+      'idempotent', true,
+      'created_at', existing_entry.created_at
+    );
+end;
+$$;
+
+drop function if exists public.apply_member_wallet_entry(text, numeric, uuid, text, jsonb);
+
+revoke execute on function public.apply_member_wallet_entry(uuid, text, numeric, uuid, text, jsonb) from public;
+revoke execute on function public.apply_member_wallet_entry(uuid, text, numeric, uuid, text, jsonb) from anon;
+revoke execute on function public.apply_member_wallet_entry(uuid, text, numeric, uuid, text, jsonb) from authenticated;
+grant execute on function public.apply_member_wallet_entry(uuid, text, numeric, uuid, text, jsonb) to service_role;

--- a/supabase/migrations/20260502162017_grant_member_service_role_tables.sql
+++ b/supabase/migrations/20260502162017_grant_member_service_role_tables.sql
@@ -1,0 +1,12 @@
+grant usage on schema public to service_role;
+
+grant select, insert, update on table public.profiles to service_role;
+grant select, insert, update on table public.member_settings to service_role;
+grant select, insert, update on table public.member_wallets to service_role;
+grant select, insert, update on table public.member_game_progress to service_role;
+grant select, insert on table public.member_events to service_role;
+
+grant select, insert on table public.member_wallet_ledger to service_role;
+grant select, insert on table public.member_game_rounds to service_role;
+grant select, insert on table public.member_ad_rewards to service_role;
+grant select, insert on table public.member_purchases to service_role;

--- a/supabase/migrations/20260502_fix_member_security_advisors.sql
+++ b/supabase/migrations/20260502_fix_member_security_advisors.sql
@@ -1,0 +1,25 @@
+create or replace function public.set_updated_at()
+returns trigger
+language plpgsql
+set search_path = public
+as $$
+begin
+  new.updated_at = timezone('utc', now());
+  return new;
+end;
+$$;
+
+revoke execute on function public.handle_new_auth_user() from public;
+revoke execute on function public.handle_new_auth_user() from anon;
+revoke execute on function public.handle_new_auth_user() from authenticated;
+
+revoke execute on function public.handle_new_member_data() from public;
+revoke execute on function public.handle_new_member_data() from anon;
+revoke execute on function public.handle_new_member_data() from authenticated;
+
+revoke execute on function public.rls_auto_enable() from public;
+revoke execute on function public.rls_auto_enable() from anon;
+revoke execute on function public.rls_auto_enable() from authenticated;
+
+create index if not exists member_events_user_created_at_idx
+on public.member_events (user_id, created_at desc);

--- a/supabase/migrations/20260502_harden_member_wallet_writes.sql
+++ b/supabase/migrations/20260502_harden_member_wallet_writes.sql
@@ -1,0 +1,2 @@
+drop policy if exists "Members can insert their own wallets" on public.member_wallets;
+drop policy if exists "Members can update their own wallets" on public.member_wallets;

--- a/supabase/migrations/20260502_member_mvp_facts.sql
+++ b/supabase/migrations/20260502_member_mvp_facts.sql
@@ -1,0 +1,128 @@
+create table if not exists public.member_wallet_ledger (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  source text not null check (source in ('game_round', 'ad_reward', 'purchase', 'admin_adjustment', 'system')),
+  amount numeric(14, 2) not null,
+  balance_before numeric(14, 2) not null,
+  balance_after numeric(14, 2) not null,
+  currency text not null default 'USD' check (currency = 'USD'),
+  reference_id uuid,
+  idempotency_key text,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default timezone('utc', now()),
+  check (balance_after = balance_before + amount)
+);
+
+create table if not exists public.member_game_rounds (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  game_slug text not null,
+  round_status text not null check (round_status in ('settled', 'rejected', 'voided')),
+  total_stake numeric(14, 2) not null default 0 check (total_stake >= 0),
+  delta numeric(14, 2) not null default 0,
+  outcome text not null check (outcome in ('win', 'loss', 'push')),
+  result_summary text not null default '',
+  bet_snapshot jsonb not null default '{}'::jsonb,
+  result_snapshot jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default timezone('utc', now())
+);
+
+create table if not exists public.member_ad_rewards (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  placement text not null check (placement in ('daily_bonus', 'loss_recovery', 'lobby_reward')),
+  reward_amount numeric(14, 2) not null default 0 check (reward_amount >= 0),
+  status text not null check (status in ('started', 'completed', 'credited', 'failed')),
+  created_at timestamptz not null default timezone('utc', now()),
+  credited_at timestamptz,
+  check (status <> 'credited' or credited_at is not null)
+);
+
+create table if not exists public.member_purchases (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  product_id text not null,
+  amount numeric(14, 2) not null default 0 check (amount >= 0),
+  credits numeric(14, 2) not null default 0 check (credits >= 0),
+  status text not null check (status in ('created', 'succeeded', 'failed', 'canceled', 'credited')),
+  provider text not null default 'stub',
+  provider_reference text,
+  created_at timestamptz not null default timezone('utc', now()),
+  credited_at timestamptz,
+  check (status <> 'credited' or credited_at is not null)
+);
+
+create unique index if not exists member_wallet_ledger_idempotency_key_idx
+on public.member_wallet_ledger (idempotency_key)
+where idempotency_key is not null;
+
+create unique index if not exists member_wallet_ledger_source_reference_idx
+on public.member_wallet_ledger (source, reference_id)
+where reference_id is not null;
+
+create index if not exists member_wallet_ledger_user_created_at_idx
+on public.member_wallet_ledger (user_id, created_at desc);
+
+create index if not exists member_wallet_ledger_reference_idx
+on public.member_wallet_ledger (reference_id)
+where reference_id is not null;
+
+create index if not exists member_game_rounds_user_created_at_idx
+on public.member_game_rounds (user_id, created_at desc);
+
+create index if not exists member_game_rounds_user_game_created_at_idx
+on public.member_game_rounds (user_id, game_slug, created_at desc);
+
+create index if not exists member_ad_rewards_user_created_at_idx
+on public.member_ad_rewards (user_id, created_at desc);
+
+create index if not exists member_purchases_user_created_at_idx
+on public.member_purchases (user_id, created_at desc);
+
+create unique index if not exists member_purchases_provider_reference_idx
+on public.member_purchases (provider, provider_reference)
+where provider_reference is not null;
+
+alter table public.member_wallet_ledger enable row level security;
+alter table public.member_game_rounds enable row level security;
+alter table public.member_ad_rewards enable row level security;
+alter table public.member_purchases enable row level security;
+
+drop policy if exists "Members can update their own wallets" on public.member_wallets;
+drop policy if exists "Members can insert their own wallets" on public.member_wallets;
+
+drop policy if exists "Members can read their own wallet ledger" on public.member_wallet_ledger;
+create policy "Members can read their own wallet ledger"
+on public.member_wallet_ledger for select
+to authenticated
+using ((select auth.uid()) = user_id);
+
+drop policy if exists "Members can insert their own wallet ledger stubs" on public.member_wallet_ledger;
+
+drop policy if exists "Members can read their own game rounds" on public.member_game_rounds;
+create policy "Members can read their own game rounds"
+on public.member_game_rounds for select
+to authenticated
+using ((select auth.uid()) = user_id);
+
+drop policy if exists "Members can insert their own game round stubs" on public.member_game_rounds;
+
+drop policy if exists "Members can read their own ad rewards" on public.member_ad_rewards;
+create policy "Members can read their own ad rewards"
+on public.member_ad_rewards for select
+to authenticated
+using ((select auth.uid()) = user_id);
+
+drop policy if exists "Members can insert their own ad reward stubs" on public.member_ad_rewards;
+
+drop policy if exists "Members can update their own ad reward stubs" on public.member_ad_rewards;
+
+drop policy if exists "Members can read their own purchases" on public.member_purchases;
+create policy "Members can read their own purchases"
+on public.member_purchases for select
+to authenticated
+using ((select auth.uid()) = user_id);
+
+drop policy if exists "Members can insert their own purchase stubs" on public.member_purchases;
+
+drop policy if exists "Members can update their own purchase stubs" on public.member_purchases;

--- a/supabase/migrations/20260503162614_member_round_idempotency.sql
+++ b/supabase/migrations/20260503162614_member_round_idempotency.sql
@@ -1,0 +1,6 @@
+alter table public.member_game_rounds
+add column if not exists idempotency_key text;
+
+create unique index if not exists member_game_rounds_user_idempotency_key_idx
+on public.member_game_rounds (user_id, idempotency_key)
+where idempotency_key is not null;

--- a/supabase/migrations/20260505114656_member_table_sessions.sql
+++ b/supabase/migrations/20260505114656_member_table_sessions.sql
@@ -1,0 +1,473 @@
+do $$
+declare
+  source_constraint_name text;
+begin
+  select conname
+  into source_constraint_name
+  from pg_constraint
+  where conrelid = 'public.member_wallet_ledger'::regclass
+    and contype = 'c'
+    and pg_get_constraintdef(oid) like '%source%';
+
+  if source_constraint_name is not null then
+    execute format('alter table public.member_wallet_ledger drop constraint %I', source_constraint_name);
+  end if;
+end $$;
+
+alter table public.member_wallet_ledger
+add constraint member_wallet_ledger_source_check
+check (source in ('game_round', 'ad_reward', 'purchase', 'admin_adjustment', 'system', 'table_buy_in', 'table_cash_out'));
+
+create table if not exists public.member_table_sessions (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  game_slug text not null,
+  status text not null default 'active' check (status in ('active', 'cashed_out', 'abandoned')),
+  buy_in_amount numeric(14, 2) not null check (buy_in_amount > 0),
+  chip_balance numeric(14, 2) not null check (chip_balance >= 0),
+  wallet_ledger_id uuid references public.member_wallet_ledger(id),
+  cash_out_ledger_id uuid references public.member_wallet_ledger(id),
+  idempotency_key text,
+  metadata jsonb not null default '{}'::jsonb,
+  opened_at timestamptz not null default timezone('utc', now()),
+  closed_at timestamptz,
+  updated_at timestamptz not null default timezone('utc', now()),
+  check (status = 'active' or closed_at is not null),
+  check (status <> 'cashed_out' or chip_balance = 0)
+);
+
+create unique index if not exists member_table_sessions_user_idempotency_key_idx
+on public.member_table_sessions (user_id, idempotency_key)
+where idempotency_key is not null;
+
+create unique index if not exists member_table_sessions_one_active_game_idx
+on public.member_table_sessions (user_id, game_slug)
+where status = 'active';
+
+create index if not exists member_table_sessions_user_opened_at_idx
+on public.member_table_sessions (user_id, opened_at desc);
+
+alter table public.member_game_rounds
+add column if not exists table_session_id uuid references public.member_table_sessions(id),
+add column if not exists chip_balance_before numeric(14, 2),
+add column if not exists chip_balance_after numeric(14, 2);
+
+create index if not exists member_game_rounds_table_session_created_at_idx
+on public.member_game_rounds (table_session_id, created_at desc)
+where table_session_id is not null;
+
+alter table public.member_table_sessions enable row level security;
+
+drop policy if exists "Members can read their own table sessions" on public.member_table_sessions;
+create policy "Members can read their own table sessions"
+on public.member_table_sessions for select
+to authenticated
+using ((select auth.uid()) = user_id);
+
+grant select on table public.member_table_sessions to authenticated;
+grant select, insert, update on table public.member_table_sessions to service_role;
+
+create or replace function public.apply_member_wallet_entry(
+  p_user_id uuid,
+  p_source text,
+  p_amount numeric,
+  p_reference_id uuid default null,
+  p_idempotency_key text default null,
+  p_metadata jsonb default '{}'::jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  member_id uuid := p_user_id;
+  existing_entry public.member_wallet_ledger%rowtype;
+  current_balance numeric(14, 2);
+  next_balance numeric(14, 2);
+  ledger_entry public.member_wallet_ledger%rowtype;
+begin
+  if member_id is null then
+    raise exception 'Wallet user id is required.' using errcode = '22004';
+  end if;
+
+  if p_source not in ('game_round', 'ad_reward', 'purchase', 'admin_adjustment', 'system', 'table_buy_in', 'table_cash_out') then
+    raise exception 'Unsupported wallet source: %', p_source using errcode = '22023';
+  end if;
+
+  if p_amount is null then
+    raise exception 'Wallet amount is required.' using errcode = '22004';
+  end if;
+
+  if p_idempotency_key is not null then
+    select *
+    into existing_entry
+    from public.member_wallet_ledger
+    where member_wallet_ledger.idempotency_key = p_idempotency_key
+      and member_wallet_ledger.user_id = member_id
+    limit 1;
+
+    if found then
+      return jsonb_build_object(
+        'ledger_id', existing_entry.id,
+        'balance_before', existing_entry.balance_before,
+        'balance_after', existing_entry.balance_after,
+        'amount', existing_entry.amount,
+        'currency', existing_entry.currency,
+        'idempotent', true,
+        'created_at', existing_entry.created_at
+      );
+    end if;
+  end if;
+
+  insert into public.member_wallets (user_id)
+  values (member_id)
+  on conflict (user_id) do nothing;
+
+  select balance
+  into current_balance
+  from public.member_wallets
+  where user_id = member_id
+  for update;
+
+  if current_balance is null then
+    raise exception 'Member wallet is unavailable.' using errcode = 'P0002';
+  end if;
+
+  next_balance := round(current_balance + p_amount, 2);
+
+  if next_balance < 0 then
+    raise exception 'Insufficient wallet balance.' using errcode = 'P0001';
+  end if;
+
+  insert into public.member_wallet_ledger (
+    user_id,
+    source,
+    amount,
+    balance_before,
+    balance_after,
+    reference_id,
+    idempotency_key,
+    metadata
+  )
+  values (
+    member_id,
+    p_source,
+    round(p_amount, 2),
+    current_balance,
+    next_balance,
+    p_reference_id,
+    p_idempotency_key,
+    coalesce(p_metadata, '{}'::jsonb)
+  )
+  returning * into ledger_entry;
+
+  update public.member_wallets
+  set balance = next_balance,
+      updated_at = timezone('utc', now())
+  where user_id = member_id;
+
+  return jsonb_build_object(
+    'ledger_id', ledger_entry.id,
+    'balance_before', ledger_entry.balance_before,
+    'balance_after', ledger_entry.balance_after,
+    'amount', ledger_entry.amount,
+    'currency', ledger_entry.currency,
+    'idempotent', false,
+    'created_at', ledger_entry.created_at
+  );
+exception
+  when unique_violation then
+    if p_idempotency_key is null then
+      raise;
+    end if;
+
+    select *
+    into existing_entry
+    from public.member_wallet_ledger
+    where member_wallet_ledger.idempotency_key = p_idempotency_key
+      and member_wallet_ledger.user_id = member_id
+    limit 1;
+
+    if not found then
+      raise;
+    end if;
+
+    return jsonb_build_object(
+      'ledger_id', existing_entry.id,
+      'balance_before', existing_entry.balance_before,
+      'balance_after', existing_entry.balance_after,
+      'amount', existing_entry.amount,
+      'currency', existing_entry.currency,
+      'idempotent', true,
+      'created_at', existing_entry.created_at
+    );
+end;
+$$;
+
+create or replace function public.open_member_table_session(
+  p_user_id uuid,
+  p_game_slug text,
+  p_buy_in_amount numeric,
+  p_idempotency_key text default null,
+  p_metadata jsonb default '{}'::jsonb
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  member_id uuid := p_user_id;
+  normalized_buy_in numeric(14, 2) := round(p_buy_in_amount, 2);
+  existing_session public.member_table_sessions%rowtype;
+  session_id uuid := gen_random_uuid();
+  wallet_entry jsonb;
+  inserted_session public.member_table_sessions%rowtype;
+begin
+  if member_id is null then
+    raise exception 'Table session user id is required.' using errcode = '22004';
+  end if;
+
+  if p_game_slug is null or length(trim(p_game_slug)) = 0 then
+    raise exception 'Game slug is required.' using errcode = '22004';
+  end if;
+
+  if normalized_buy_in <= 0 then
+    raise exception 'Buy-in amount must be greater than zero.' using errcode = '22023';
+  end if;
+
+  if p_idempotency_key is not null then
+    select *
+    into existing_session
+    from public.member_table_sessions
+    where user_id = member_id
+      and idempotency_key = p_idempotency_key
+    limit 1;
+
+    if found then
+      return jsonb_build_object(
+        'session', to_jsonb(existing_session),
+        'wallet_entry', null,
+        'idempotent', true
+      );
+    end if;
+  end if;
+
+  select *
+  into existing_session
+  from public.member_table_sessions
+  where user_id = member_id
+    and game_slug = p_game_slug
+    and status = 'active'
+  order by opened_at desc
+  limit 1;
+
+  if found then
+    return jsonb_build_object(
+      'session', to_jsonb(existing_session),
+      'wallet_entry', null,
+      'idempotent', true
+    );
+  end if;
+
+  wallet_entry := public.apply_member_wallet_entry(
+    member_id,
+    'table_buy_in',
+    -normalized_buy_in,
+    session_id,
+    case when p_idempotency_key is null then null else 'table-buy-in:' || p_idempotency_key end,
+    jsonb_build_object('gameSlug', p_game_slug, 'tableSessionId', session_id) || coalesce(p_metadata, '{}'::jsonb)
+  );
+
+  insert into public.member_table_sessions (
+    id,
+    user_id,
+    game_slug,
+    status,
+    buy_in_amount,
+    chip_balance,
+    wallet_ledger_id,
+    idempotency_key,
+    metadata
+  )
+  values (
+    session_id,
+    member_id,
+    p_game_slug,
+    'active',
+    normalized_buy_in,
+    normalized_buy_in,
+    (wallet_entry->>'ledger_id')::uuid,
+    p_idempotency_key,
+    coalesce(p_metadata, '{}'::jsonb)
+  )
+  returning * into inserted_session;
+
+  return jsonb_build_object(
+    'session', to_jsonb(inserted_session),
+    'wallet_entry', wallet_entry,
+    'idempotent', false
+  );
+exception
+  when unique_violation then
+    if p_idempotency_key is not null then
+      select *
+      into existing_session
+      from public.member_table_sessions
+      where user_id = member_id
+        and idempotency_key = p_idempotency_key
+      limit 1;
+
+      if found then
+        return jsonb_build_object(
+          'session', to_jsonb(existing_session),
+          'wallet_entry', null,
+          'idempotent', true
+        );
+      end if;
+    end if;
+
+    raise;
+end;
+$$;
+
+create or replace function public.cash_out_member_table_session(
+  p_user_id uuid,
+  p_session_id uuid,
+  p_idempotency_key text default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  member_id uuid := p_user_id;
+  table_session public.member_table_sessions%rowtype;
+  wallet_entry jsonb := null;
+  cash_out_amount numeric(14, 2);
+begin
+  if member_id is null or p_session_id is null then
+    raise exception 'Table session user id and session id are required.' using errcode = '22004';
+  end if;
+
+  select *
+  into table_session
+  from public.member_table_sessions
+  where id = p_session_id
+    and user_id = member_id
+  for update;
+
+  if not found then
+    raise exception 'Table session was not found.' using errcode = 'P0002';
+  end if;
+
+  if table_session.status <> 'active' then
+    return jsonb_build_object(
+      'session', to_jsonb(table_session),
+      'wallet_entry', null,
+      'idempotent', true
+    );
+  end if;
+
+  cash_out_amount := table_session.chip_balance;
+
+  if cash_out_amount > 0 then
+    wallet_entry := public.apply_member_wallet_entry(
+      member_id,
+      'table_cash_out',
+      cash_out_amount,
+      table_session.id,
+      coalesce(p_idempotency_key, 'table-cash-out:' || table_session.id),
+      jsonb_build_object('gameSlug', table_session.game_slug, 'tableSessionId', table_session.id)
+    );
+  end if;
+
+  update public.member_table_sessions
+  set status = 'cashed_out',
+      chip_balance = 0,
+      cash_out_ledger_id = case when wallet_entry is null then null else (wallet_entry->>'ledger_id')::uuid end,
+      closed_at = timezone('utc', now()),
+      updated_at = timezone('utc', now())
+  where id = table_session.id
+  returning * into table_session;
+
+  return jsonb_build_object(
+    'session', to_jsonb(table_session),
+    'wallet_entry', wallet_entry,
+    'cash_out_amount', cash_out_amount,
+    'idempotent', false
+  );
+end;
+$$;
+
+create or replace function public.apply_member_table_session_delta(
+  p_user_id uuid,
+  p_session_id uuid,
+  p_delta numeric
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  member_id uuid := p_user_id;
+  table_session public.member_table_sessions%rowtype;
+  normalized_delta numeric(14, 2) := round(p_delta, 2);
+  balance_before numeric(14, 2);
+  balance_after numeric(14, 2);
+begin
+  if member_id is null or p_session_id is null then
+    raise exception 'Table session user id and session id are required.' using errcode = '22004';
+  end if;
+
+  select *
+  into table_session
+  from public.member_table_sessions
+  where id = p_session_id
+    and user_id = member_id
+    and status = 'active'
+  for update;
+
+  if not found then
+    raise exception 'Active table session was not found.' using errcode = 'P0002';
+  end if;
+
+  balance_before := table_session.chip_balance;
+  balance_after := round(balance_before + normalized_delta, 2);
+
+  if balance_after < 0 then
+    raise exception 'Insufficient table chips.' using errcode = 'P0001';
+  end if;
+
+  update public.member_table_sessions
+  set chip_balance = balance_after,
+      updated_at = timezone('utc', now())
+  where id = table_session.id
+  returning * into table_session;
+
+  return jsonb_build_object(
+    'session', to_jsonb(table_session),
+    'chip_balance_before', balance_before,
+    'chip_balance_after', balance_after,
+    'delta', normalized_delta
+  );
+end;
+$$;
+
+revoke execute on function public.open_member_table_session(uuid, text, numeric, text, jsonb) from public;
+revoke execute on function public.open_member_table_session(uuid, text, numeric, text, jsonb) from anon;
+revoke execute on function public.open_member_table_session(uuid, text, numeric, text, jsonb) from authenticated;
+grant execute on function public.open_member_table_session(uuid, text, numeric, text, jsonb) to service_role;
+
+revoke execute on function public.cash_out_member_table_session(uuid, uuid, text) from public;
+revoke execute on function public.cash_out_member_table_session(uuid, uuid, text) from anon;
+revoke execute on function public.cash_out_member_table_session(uuid, uuid, text) from authenticated;
+grant execute on function public.cash_out_member_table_session(uuid, uuid, text) to service_role;
+
+revoke execute on function public.apply_member_table_session_delta(uuid, uuid, numeric) from public;
+revoke execute on function public.apply_member_table_session_delta(uuid, uuid, numeric) from anon;
+revoke execute on function public.apply_member_table_session_delta(uuid, uuid, numeric) from authenticated;
+grant execute on function public.apply_member_table_session_delta(uuid, uuid, numeric) to service_role;

--- a/supabase/migrations/20260509120000_settle_member_table_session_round.sql
+++ b/supabase/migrations/20260509120000_settle_member_table_session_round.sql
@@ -1,0 +1,234 @@
+create or replace function public.settle_member_table_session_round(
+  p_user_id uuid,
+  p_session_id uuid,
+  p_game_slug text,
+  p_outcome text,
+  p_delta numeric,
+  p_total_stake numeric,
+  p_summary text default '',
+  p_bet_snapshot jsonb default '{}'::jsonb,
+  p_result_snapshot jsonb default '{}'::jsonb,
+  p_idempotency_key text default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  member_id uuid := p_user_id;
+  normalized_delta numeric(14, 2) := round(p_delta, 2);
+  normalized_stake numeric(14, 2) := greatest(0, round(p_total_stake, 2));
+  table_session public.member_table_sessions%rowtype;
+  existing_round public.member_game_rounds%rowtype;
+  game_progress public.member_game_progress%rowtype;
+  game_round public.member_game_rounds%rowtype;
+  balance_before numeric(14, 2);
+  balance_after numeric(14, 2);
+begin
+  if member_id is null or p_session_id is null then
+    raise exception 'Table session user id and session id are required.' using errcode = '22004';
+  end if;
+
+  if coalesce(nullif(p_game_slug, ''), '') = '' then
+    raise exception 'A game slug is required.' using errcode = '22004';
+  end if;
+
+  if p_outcome not in ('win', 'loss', 'push') then
+    raise exception 'A valid round outcome is required.' using errcode = '22004';
+  end if;
+
+  if p_idempotency_key is not null then
+    select *
+    into existing_round
+    from public.member_game_rounds
+    where user_id = member_id
+      and idempotency_key = p_idempotency_key;
+
+    if found then
+      select *
+      into table_session
+      from public.member_table_sessions
+      where id = coalesce(existing_round.table_session_id, p_session_id)
+        and user_id = member_id;
+
+      select *
+      into game_progress
+      from public.member_game_progress
+      where user_id = member_id
+        and game_slug = existing_round.game_slug;
+
+      return jsonb_build_object(
+        'session', to_jsonb(table_session),
+        'progress', to_jsonb(game_progress),
+        'round', to_jsonb(existing_round),
+        'chip_balance_before', existing_round.chip_balance_before,
+        'chip_balance_after', existing_round.chip_balance_after,
+        'delta', existing_round.delta,
+        'idempotent', true
+      );
+    end if;
+  end if;
+
+  select *
+  into table_session
+  from public.member_table_sessions
+  where id = p_session_id
+    and user_id = member_id
+    and status = 'active'
+  for update;
+
+  if not found then
+    raise exception 'Active table session was not found.' using errcode = 'P0002';
+  end if;
+
+  if table_session.game_slug <> p_game_slug then
+    raise exception 'Table session game does not match round game.' using errcode = '22000';
+  end if;
+
+  if p_idempotency_key is not null then
+    select *
+    into existing_round
+    from public.member_game_rounds
+    where user_id = member_id
+      and idempotency_key = p_idempotency_key;
+
+    if found then
+      select *
+      into game_progress
+      from public.member_game_progress
+      where user_id = member_id
+        and game_slug = existing_round.game_slug;
+
+      return jsonb_build_object(
+        'session', to_jsonb(table_session),
+        'progress', to_jsonb(game_progress),
+        'round', to_jsonb(existing_round),
+        'chip_balance_before', existing_round.chip_balance_before,
+        'chip_balance_after', existing_round.chip_balance_after,
+        'delta', existing_round.delta,
+        'idempotent', true
+      );
+    end if;
+  end if;
+
+  balance_before := table_session.chip_balance;
+  balance_after := round(balance_before + normalized_delta, 2);
+
+  if balance_after < 0 then
+    raise exception 'Insufficient table chips.' using errcode = 'P0001';
+  end if;
+
+  update public.member_table_sessions
+  set chip_balance = balance_after,
+      updated_at = timezone('utc', now())
+  where id = table_session.id
+  returning * into table_session;
+
+  insert into public.member_game_progress (
+    user_id,
+    game_slug,
+    plays,
+    wins,
+    losses,
+    streak,
+    best_streak,
+    bankroll,
+    last_result,
+    last_delta,
+    last_summary,
+    last_played_at
+  )
+  values (
+    member_id,
+    p_game_slug,
+    1,
+    case when p_outcome = 'win' then 1 else 0 end,
+    case when p_outcome = 'loss' then 1 else 0 end,
+    case when p_outcome = 'win' then 1 else 0 end,
+    case when p_outcome = 'win' then 1 else 0 end,
+    balance_after,
+    p_outcome,
+    normalized_delta,
+    left(coalesce(p_summary, ''), 280),
+    timezone('utc', now())
+  )
+  on conflict (user_id, game_slug) do update
+  set plays = public.member_game_progress.plays + 1,
+      wins = public.member_game_progress.wins + case when excluded.last_result = 'win' then 1 else 0 end,
+      losses = public.member_game_progress.losses + case when excluded.last_result = 'loss' then 1 else 0 end,
+      streak = case
+        when excluded.last_result = 'win' then public.member_game_progress.streak + 1
+        when excluded.last_result = 'loss' then 0
+        else public.member_game_progress.streak
+      end,
+      best_streak = greatest(
+        public.member_game_progress.best_streak,
+        case
+          when excluded.last_result = 'win' then public.member_game_progress.streak + 1
+          when excluded.last_result = 'loss' then 0
+          else public.member_game_progress.streak
+        end
+      ),
+      bankroll = balance_after,
+      last_result = excluded.last_result,
+      last_delta = excluded.last_delta,
+      last_summary = excluded.last_summary,
+      last_played_at = excluded.last_played_at
+  returning * into game_progress;
+
+  insert into public.member_game_rounds (
+    user_id,
+    game_slug,
+    table_session_id,
+    round_status,
+    total_stake,
+    delta,
+    outcome,
+    chip_balance_before,
+    chip_balance_after,
+    result_summary,
+    bet_snapshot,
+    result_snapshot,
+    idempotency_key
+  )
+  values (
+    member_id,
+    p_game_slug,
+    table_session.id,
+    'settled',
+    normalized_stake,
+    normalized_delta,
+    p_outcome,
+    balance_before,
+    balance_after,
+    left(coalesce(p_summary, ''), 280),
+    coalesce(p_bet_snapshot, '{}'::jsonb),
+    coalesce(p_result_snapshot, '{}'::jsonb) || jsonb_build_object(
+      'tableSessionId', table_session.id,
+      'chipBalanceBefore', balance_before,
+      'chipBalanceAfter', balance_after
+    ),
+    p_idempotency_key
+  )
+  returning * into game_round;
+
+  insert into public.member_events (user_id, kind, title, detail)
+  values (member_id, 'game', p_game_slug || ' ' || p_outcome, left(coalesce(p_summary, ''), 280));
+
+  return jsonb_build_object(
+    'session', to_jsonb(table_session),
+    'progress', to_jsonb(game_progress),
+    'round', to_jsonb(game_round),
+    'chip_balance_before', balance_before,
+    'chip_balance_after', balance_after,
+    'delta', normalized_delta,
+    'idempotent', false
+  );
+end;
+$$;
+
+revoke execute on function public.settle_member_table_session_round(uuid, uuid, text, text, numeric, numeric, text, jsonb, jsonb, text) from public;
+revoke execute on function public.settle_member_table_session_round(uuid, uuid, text, text, numeric, numeric, text, jsonb, jsonb, text) from anon;
+revoke execute on function public.settle_member_table_session_round(uuid, uuid, text, text, numeric, numeric, text, jsonb, jsonb, text) from authenticated;
+grant execute on function public.settle_member_table_session_round(uuid, uuid, text, text, numeric, numeric, text, jsonb, jsonb, text) to service_role;


### PR DESCRIPTION
﻿## Summary

This PR closes the GHO-19 backend wallet/table-session loop for the TaihuCasino member experience.

- Adds Supabase migrations for member wallet facts, ledger hardening, service-role access, round idempotency, and table sessions.
- Adds member table-session APIs for buy-in, active-session lookup, and cash-out.
- Wires Baccarat, Blackjack, Roulette, and Dice to backend-backed buy-in/cash-out chip flows.
- Connects the player home page, recent history, weekly win/loss board, settings, and test wallet top-up to live member data.
- Keeps Supabase local temp files out of git and adds the Supabase CLI dependency/workspace support needed for this backend flow.

## 中文说明

这个 PR 收口 GHO-19 的会员钱包与桌台 session 后端闭环。

- 新增会员钱包事实表、流水加固、service role 权限、牌局幂等、桌台 session 相关 Supabase 迁移。
- 新增会员桌台 session API：买入、查询当前 session、退桌结算。
- 将百家乐、21 点、轮盘、骰子接入后端驱动的买入/退桌筹码流程。
- 将玩家首页、最近记录、一周输赢榜、设置页、测试钱包充值接到真实会员数据。
- 忽略 Supabase 本地临时目录，并补齐本轮后端流程需要的 Supabase CLI 依赖与 workspace 配置。

## Validation

- `corepack pnpm typecheck`
- `corepack pnpm build`
- Browser smoke tested Blackjack, Roulette, and Dice buy-in -> play -> cash-out flows.

## 验证

- `corepack pnpm typecheck`
- `corepack pnpm build`
- 已用浏览器冒烟验证 Blackjack / Roulette / Dice 的买入 -> 游玩 -> 退桌流程。

## Known Follow-Up

Old smoke-test rows from earlier backend verification still remain in Supabase because REST delete permissions and direct database connection cleanup were blocked. They should be removed later through Supabase SQL/Dashboard access using the known smoke idempotency filters.

## 已知后续项

早期后端验证留下的旧 smoke 测试记录仍在 Supabase 中；REST 删除权限和数据库直连清理都被挡住了。后续需要通过 Supabase SQL/Dashboard 权限按 smoke idempotency 标记清理。
