### PR TITLE
完成会员钱包与游戏回合闭环 / Complete member wallet and game-round loop

### DIFF
--- a/app/api/member/ad-rewards/complete/route.ts
+++ b/app/api/member/ad-rewards/complete/route.ts
@@ -1,0 +1,49 @@
+import { cookies } from "next/headers"
+import { NextResponse } from "next/server"
+
+import { completeAdReward, isSameOriginMutation } from "@/lib/member-data"
+
+export async function POST(request: Request) {
+  if (!isSameOriginMutation(request)) {
+    return NextResponse.json({ error: "Cross-origin mutation rejected." }, { status: 403 })
+  }
+
+  const response = NextResponse.json(
+    { adReward: null },
+    {
+      headers: {
+        "cache-control": "private, no-store",
+      },
+    },
+  )
+  const cookieStore = await cookies()
+
+  try {
+    const result = await completeAdReward(cookieStore, response, await request.json().catch(() => null))
+
+    if (!result) {
+      return NextResponse.json(
+        { error: "Authentication is required." },
+        {
+          status: 401,
+          headers: response.headers,
+        },
+      )
+    }
+
+    return NextResponse.json(
+      result,
+      {
+        headers: response.headers,
+      },
+    )
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Unable to complete ad reward." },
+      {
+        status: 400,
+        headers: response.headers,
+      },
+    )
+  }
+}

--- a/app/api/member/ad-rewards/start/route.ts
+++ b/app/api/member/ad-rewards/start/route.ts
@@ -1,0 +1,49 @@
+import { cookies } from "next/headers"
+import { NextResponse } from "next/server"
+
+import { isSameOriginMutation, startAdReward } from "@/lib/member-data"
+
+export async function POST(request: Request) {
+  if (!isSameOriginMutation(request)) {
+    return NextResponse.json({ error: "Cross-origin mutation rejected." }, { status: 403 })
+  }
+
+  const response = NextResponse.json(
+    { adReward: null },
+    {
+      headers: {
+        "cache-control": "private, no-store",
+      },
+    },
+  )
+  const cookieStore = await cookies()
+
+  try {
+    const adReward = await startAdReward(cookieStore, response, await request.json().catch(() => null))
+
+    if (!adReward) {
+      return NextResponse.json(
+        { error: "Authentication is required." },
+        {
+          status: 401,
+          headers: response.headers,
+        },
+      )
+    }
+
+    return NextResponse.json(
+      { adReward },
+      {
+        headers: response.headers,
+      },
+    )
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Unable to start ad reward." },
+      {
+        status: 400,
+        headers: response.headers,
+      },
+    )
+  }
+}

--- a/app/api/member/events/route.ts
+++ b/app/api/member/events/route.ts
@@ -1,0 +1,79 @@
+import { cookies } from "next/headers"
+import { NextResponse } from "next/server"
+
+import { isSameOriginMutation, readMemberOverview, recordMemberEvent } from "@/lib/member-data"
+
+export async function GET() {
+  const response = NextResponse.json(
+    { events: [] },
+    {
+      headers: {
+        "cache-control": "private, no-store",
+      },
+    },
+  )
+  const cookieStore = await cookies()
+  const member = await readMemberOverview(cookieStore, response)
+
+  if (!member) {
+    return NextResponse.json(
+      { error: "Authentication is required." },
+      {
+        status: 401,
+        headers: response.headers,
+      },
+    )
+  }
+
+  return NextResponse.json(
+    { events: member.recentEvents },
+    {
+      headers: response.headers,
+    },
+  )
+}
+
+export async function POST(request: Request) {
+  if (!isSameOriginMutation(request)) {
+    return NextResponse.json({ error: "Cross-origin mutation rejected." }, { status: 403 })
+  }
+
+  const response = NextResponse.json(
+    { event: null },
+    {
+      headers: {
+        "cache-control": "private, no-store",
+      },
+    },
+  )
+  const cookieStore = await cookies()
+
+  try {
+    const event = await recordMemberEvent(cookieStore, response, await request.json().catch(() => null))
+
+    if (!event) {
+      return NextResponse.json(
+        { error: "Authentication is required." },
+        {
+          status: 401,
+          headers: response.headers,
+        },
+      )
+    }
+
+    return NextResponse.json(
+      { event },
+      {
+        headers: response.headers,
+      },
+    )
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Unable to record member event." },
+      {
+        status: 400,
+        headers: response.headers,
+      },
+    )
+  }
+}

--- a/app/api/member/game-rounds/route.ts
+++ b/app/api/member/game-rounds/route.ts
@@ -1,0 +1,79 @@
+import { cookies } from "next/headers"
+import { NextResponse } from "next/server"
+
+import { isSameOriginMutation, readMemberOverview, recordGameProgress } from "@/lib/member-data"
+
+export async function GET() {
+  const response = NextResponse.json(
+    { rounds: [] },
+    {
+      headers: {
+        "cache-control": "private, no-store",
+      },
+    },
+  )
+  const cookieStore = await cookies()
+  const member = await readMemberOverview(cookieStore, response)
+
+  if (!member) {
+    return NextResponse.json(
+      { error: "Authentication is required." },
+      {
+        status: 401,
+        headers: response.headers,
+      },
+    )
+  }
+
+  return NextResponse.json(
+    { rounds: member.gameRounds, progress: member.progress },
+    {
+      headers: response.headers,
+    },
+  )
+}
+
+export async function POST(request: Request) {
+  if (!isSameOriginMutation(request)) {
+    return NextResponse.json({ error: "Cross-origin mutation rejected." }, { status: 403 })
+  }
+
+  const response = NextResponse.json(
+    { progress: null },
+    {
+      headers: {
+        "cache-control": "private, no-store",
+      },
+    },
+  )
+  const cookieStore = await cookies()
+
+  try {
+    const progress = await recordGameProgress(cookieStore, response, await request.json().catch(() => null))
+
+    if (!progress) {
+      return NextResponse.json(
+        { error: "Authentication is required." },
+        {
+          status: 401,
+          headers: response.headers,
+        },
+      )
+    }
+
+    return NextResponse.json(
+      { progress },
+      {
+        headers: response.headers,
+      },
+    )
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Unable to record game round." },
+      {
+        status: 400,
+        headers: response.headers,
+      },
+    )
+  }
+}

--- a/app/api/member/products/route.ts
+++ b/app/api/member/products/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server"
+
+import { listMemberProducts } from "@/lib/member-data"
+
+export async function GET() {
+  return NextResponse.json(
+    { products: listMemberProducts() },
+    {
+      headers: {
+        "cache-control": "private, no-store",
+      },
+    },
+  )
+}

--- a/app/api/member/purchases/[id]/complete/route.ts
+++ b/app/api/member/purchases/[id]/complete/route.ts
@@ -1,0 +1,57 @@
+import { cookies } from "next/headers"
+import { NextResponse } from "next/server"
+
+import { completePurchase, isSameOriginMutation } from "@/lib/member-data"
+
+export async function POST(
+  request: Request,
+  {
+    params,
+  }: {
+    params: Promise<{ id: string }>
+  },
+) {
+  if (!isSameOriginMutation(request)) {
+    return NextResponse.json({ error: "Cross-origin mutation rejected." }, { status: 403 })
+  }
+
+  const { id } = await params
+  const response = NextResponse.json(
+    { purchase: null },
+    {
+      headers: {
+        "cache-control": "private, no-store",
+      },
+    },
+  )
+  const cookieStore = await cookies()
+
+  try {
+    const result = await completePurchase(cookieStore, response, id)
+
+    if (!result) {
+      return NextResponse.json(
+        { error: "Authentication is required." },
+        {
+          status: 401,
+          headers: response.headers,
+        },
+      )
+    }
+
+    return NextResponse.json(
+      result,
+      {
+        headers: response.headers,
+      },
+    )
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Unable to complete purchase." },
+      {
+        status: 400,
+        headers: response.headers,
+      },
+    )
+  }
+}

--- a/app/api/member/purchases/route.ts
+++ b/app/api/member/purchases/route.ts
@@ -1,0 +1,79 @@
+import { cookies } from "next/headers"
+import { NextResponse } from "next/server"
+
+import { createPurchase, isSameOriginMutation, readMemberOverview } from "@/lib/member-data"
+
+export async function GET() {
+  const response = NextResponse.json(
+    { purchases: [] },
+    {
+      headers: {
+        "cache-control": "private, no-store",
+      },
+    },
+  )
+  const cookieStore = await cookies()
+  const member = await readMemberOverview(cookieStore, response)
+
+  if (!member) {
+    return NextResponse.json(
+      { error: "Authentication is required." },
+      {
+        status: 401,
+        headers: response.headers,
+      },
+    )
+  }
+
+  return NextResponse.json(
+    { purchases: member.purchases },
+    {
+      headers: response.headers,
+    },
+  )
+}
+
+export async function POST(request: Request) {
+  if (!isSameOriginMutation(request)) {
+    return NextResponse.json({ error: "Cross-origin mutation rejected." }, { status: 403 })
+  }
+
+  const response = NextResponse.json(
+    { purchase: null },
+    {
+      headers: {
+        "cache-control": "private, no-store",
+      },
+    },
+  )
+  const cookieStore = await cookies()
+
+  try {
+    const purchase = await createPurchase(cookieStore, response, await request.json().catch(() => null))
+
+    if (!purchase) {
+      return NextResponse.json(
+        { error: "Authentication is required." },
+        {
+          status: 401,
+          headers: response.headers,
+        },
+      )
+    }
+
+    return NextResponse.json(
+      { purchase },
+      {
+        headers: response.headers,
+      },
+    )
+  } catch (error) {
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Unable to create purchase." },
+      {
+        status: 400,
+        headers: response.headers,
+      },
+    )
+  }
+}

--- a/app/games/[slug]/page.tsx
+++ b/app/games/[slug]/page.tsx
@@ -10,6 +10,8 @@ import { RouletteTablePage } from "@/components/roulette-table-page"
 import { getPlayableTable, playableTableEntries } from "@/lib/game-catalog"
 import { readActiveTableSession, readMemberOverview } from "@/lib/member-data"
 
+export const dynamic = "force-dynamic"
+
 export function generateStaticParams() {
   return playableTableEntries.map((game) => ({ slug: game.slug }))
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,8 @@ import { redirect } from "next/navigation"
 import { PlayerHomePage } from "@/components/player-home-page"
 import { readMemberOverview } from "@/lib/member-data"
 
+export const dynamic = "force-dynamic"
+
 export default async function HomePage() {
   const cookieStore = await cookies()
   const member = await readMemberOverview(cookieStore)

--- a/components/baccarat-table-page.tsx
+++ b/components/baccarat-table-page.tsx
@@ -15,6 +15,8 @@ import { useLanguage } from "@/hooks/use-language"
 import { type Language } from "@/lib/home-content"
 import { type CasinoTableEntry } from "@/lib/game-catalog"
 import { type MemberGameProgress, type MemberTableSession } from "@/lib/member-data"
+import { recordClientGameRound } from "@/lib/member-round-client"
+import { cashOutClientTableSession, openClientTableSession } from "@/lib/table-session-client"
 import { cn } from "@/lib/utils"
 
 type BetKey = "player" | "banker" | "tie" | "playerPair" | "bankerPair"
@@ -503,42 +505,29 @@ async function persistServerProgress(
       ? `${winnerText(record.winner, language)} ${record.playerPoint}:${record.bankerPoint}，本轮 ${formatDelta(record.delta)}`
       : `${winnerText(record.winner, language)} ${record.playerPoint}:${record.bankerPoint}, round ${formatDelta(record.delta)}`
 
-  const response = await fetch("/api/member/progress", {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-    },
-    body: JSON.stringify({
-      gameSlug: entry.slug,
-      outcome: outcomeFromDelta(record.delta),
-      delta: record.delta,
-      bankroll: record.bankroll,
-      summary,
-      idempotencyKey: record.id,
-      tableSessionId,
+  return recordClientGameRound({
+    gameSlug: entry.slug,
+    outcome: outcomeFromDelta(record.delta),
+    delta: record.delta,
+    bankroll: record.bankroll,
+    summary,
+    idempotencyKey: record.id,
+    tableSessionId,
+    totalStake: record.totalStake,
+    betSnapshot: {
+      bets: record.bets,
       totalStake: record.totalStake,
-      betSnapshot: {
-        bets: record.bets,
-        totalStake: record.totalStake,
-      },
-      resultSnapshot: {
-        winner: record.winner,
-        playerPoint: record.playerPoint,
-        bankerPoint: record.bankerPoint,
-        playerCards: record.playerCards,
-        bankerCards: record.bankerCards,
-        playerPair: record.playerPair,
-        bankerPair: record.bankerPair,
-      },
-    }),
-  }).catch(() => null)
-
-  if (!response?.ok) {
-    return null
-  }
-
-  const payload = (await response.json().catch(() => null)) as { progress?: { bankroll?: unknown } } | null
-  return typeof payload?.progress?.bankroll === "number" ? payload.progress.bankroll : null
+    },
+    resultSnapshot: {
+      winner: record.winner,
+      playerPoint: record.playerPoint,
+      bankerPoint: record.bankerPoint,
+      playerCards: record.playerCards,
+      bankerCards: record.bankerCards,
+      playerPair: record.playerPair,
+      bankerPair: record.bankerPair,
+    },
+  })
 }
 
 export function BaccaratTablePage({
@@ -556,8 +545,14 @@ export function BaccaratTablePage({
 }) {
   const [language] = useLanguage(defaultLanguage)
   const isChinese = language === "zh"
+  const buyInWalletLabel = isChinese ? "主钱包余额" : "Main wallet"
+  const tableChipsLabel = isChinese ? "桌台筹码（随输赢变化）" : "Table chips (changes each hand)"
+  const mainWalletNote = isChinese ? "主钱包（买入/离桌时变化）" : "Main wallet (buy-in/cash-out only)"
+  const buyInHint = isChinese
+    ? "主钱包只在买入和离桌时变化；每手牌输赢会先结算到本桌筹码。"
+    : "Your wallet changes on buy-in and cash-out. Each hand settles into table chips first."
   const isVip = Boolean(entry.variantOf)
-  const initialBankroll = initialTableSession?.chipBalance ?? initialProgress?.bankroll ?? 0
+  const initialBankroll = initialTableSession?.chipBalance ?? 0
   const defaultChips = isVip ? [100, 250, 500, 1000, 2500] : [10, 25, 50, 100, 250]
   const defaultStake = isVip ? 250 : 25
 
@@ -567,6 +562,7 @@ export function BaccaratTablePage({
   const [buyInAmount, setBuyInAmount] = useState(isVip ? 500 : 100)
   const [isOpeningSession, setIsOpeningSession] = useState(false)
   const [isCashingOut, setIsCashingOut] = useState(false)
+  const [isSyncingRound, setIsSyncingRound] = useState(false)
   const [stake, setStake] = useState(defaultStake)
   const [chips, setChips] = useState(defaultChips)
   const [initialBankrollInput, setInitialBankrollInput] = useState(String(initialBankroll))
@@ -783,31 +779,12 @@ export function BaccaratTablePage({
     setMessage(isChinese ? "正在从钱包买入桌台筹码..." : "Buying chips from your wallet...")
 
     try {
-      const response = await fetch("/api/member/table-sessions", {
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-        },
-        body: JSON.stringify({
-          gameSlug: entry.slug,
-          buyInAmount: amount,
-          idempotencyKey: `baccarat-buy-in-${entry.slug}-${Date.now()}-${Math.random().toString(16).slice(2)}`,
-        }),
-      })
-      const payload = (await response.json().catch(() => null)) as {
-        error?: string
-        tableSession?: MemberTableSession
-        wallet?: { balance?: unknown }
-      } | null
+      const result = await openClientTableSession(entry.slug, amount, "baccarat-buy-in")
 
-      if (!response.ok || !payload?.tableSession) {
-        throw new Error(payload?.error ?? "Unable to buy in.")
-      }
-
-      setTableSession(payload.tableSession)
-      setBankroll(payload.tableSession.chipBalance)
-      setInitialBankrollInput(String(payload.tableSession.chipBalance))
-      setWalletBalance(typeof payload.wallet?.balance === "number" ? payload.wallet.balance : walletBalance - amount)
+      setTableSession(result.tableSession)
+      setBankroll(result.tableSession.chipBalance)
+      setInitialBankrollInput(String(result.tableSession.chipBalance))
+      setWalletBalance(result.walletBalance ?? walletBalance - amount)
       setBets(cloneEmptyBets())
       window.localStorage.removeItem(storageKey)
       setMessage(isChinese ? "买入成功，桌台筹码已准备好。" : "Buy-in complete. Table chips are ready.")
@@ -827,29 +804,12 @@ export function BaccaratTablePage({
     setMessage(isChinese ? "正在带走筹码并结算回钱包..." : "Cashing out table chips to your wallet...")
 
     try {
-      const response = await fetch(`/api/member/table-sessions/${tableSession.id}/cash-out`, {
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-        },
-        body: JSON.stringify({
-          idempotencyKey: `baccarat-cash-out-${tableSession.id}-${Date.now()}`,
-        }),
-      })
-      const payload = (await response.json().catch(() => null)) as {
-        error?: string
-        tableSession?: MemberTableSession
-        wallet?: { balance?: unknown }
-      } | null
-
-      if (!response.ok || !payload?.tableSession) {
-        throw new Error(payload?.error ?? "Unable to cash out.")
-      }
+      const result = await cashOutClientTableSession(tableSession.id, "baccarat-cash-out", tableSession.chipBalance)
 
       setTableSession(null)
       setBankroll(0)
       setInitialBankrollInput("0")
-      setWalletBalance(typeof payload.wallet?.balance === "number" ? payload.wallet.balance : walletBalance + tableSession.chipBalance)
+      setWalletBalance(result.walletBalance ?? walletBalance + tableSession.chipBalance)
       setBets(cloneEmptyBets())
       window.localStorage.removeItem(storageKey)
       setMessage(isChinese ? "筹码已带走，余额已回到钱包。" : "Chips cashed out. Balance returned to wallet.")
@@ -969,20 +929,28 @@ export function BaccaratTablePage({
     setBets(cloneEmptyBets())
     setVisibleDeal(null)
     setDealProgress(100)
-    setDealing(false)
     setMessage(
       isChineseThisRound
         ? `结果：${winnerText(round.winner, languageThisRound)}，本轮 ${formatDelta(delta)}。`
         : `Result: ${winnerText(round.winner, languageThisRound)}, round ${formatDelta(delta)}.`,
     )
     persistLocal(nextBankroll, nextHistory, nextStats, round)
-    void persistServerProgress(entry, record, languageThisRound, activeTableSession.id).then((serverBankroll) => {
+    setIsSyncingRound(true)
+
+    try {
+      const serverBankroll = await persistServerProgress(entry, record, languageThisRound, activeTableSession.id)
+
       if (typeof serverBankroll === "number") {
         setBankroll(serverBankroll)
         setTableSession((current) => current ? { ...current, chipBalance: serverBankroll } : current)
         persistLocal(serverBankroll, nextHistory, nextStats, round)
       }
-    })
+    } catch (error) {
+      console.error("baccarat round sync failed", error)
+    } finally {
+      setIsSyncingRound(false)
+      setDealing(false)
+    }
   }
 
   return (
@@ -1055,12 +1023,10 @@ export function BaccaratTablePage({
                   {isChinese ? "先从钱包买入本桌筹码" : "Buy chips before joining this table"}
                 </h2>
                 <p className="mt-2 max-w-2xl text-sm leading-6 text-[#cbbd91]">
-                  {isChinese
-                    ? "钱包余额不会在每手牌里直接变化；本桌下注只使用桌台筹码，离桌时再带走剩余筹码回钱包。"
-                    : "Your wallet does not change on every hand. Bets use table chips, then cash out remaining chips back to your wallet."}
+                  {buyInHint}
                 </p>
                 <p className="mt-3 text-sm font-black text-[#f4d18a]">
-                  {isChinese ? "钱包余额" : "Wallet"} {formatMoney(walletBalance)}
+                  {buyInWalletLabel} {formatMoney(walletBalance)}
                 </p>
               </div>
 
@@ -1121,12 +1087,12 @@ export function BaccaratTablePage({
                 <p className="text-sm font-black uppercase tracking-[0.16em] text-[#d0b06e]">
                   {isChinese ? "资金与发牌" : "Bankroll & Deal"}
                 </p>
-                <p className="mt-3 text-sm text-[#cbbd91]">{isChinese ? "桌台筹码" : "Table chips"}</p>
+                <p className="mt-3 text-sm text-[#cbbd91]">{tableChipsLabel}</p>
                 <p className="text-5xl font-black leading-none text-[#f4d18a] md:text-6xl">
                   {formatMoney(bankroll)}
                 </p>
                 <p className="mt-2 text-xs font-bold text-[#cbbd91]">
-                  {isChinese ? "钱包" : "Wallet"} {formatMoney(walletBalance)}
+                  {mainWalletNote} {formatMoney(walletBalance)}
                 </p>
               </div>
 
@@ -1134,7 +1100,7 @@ export function BaccaratTablePage({
                 <button
                   type="button"
                   onClick={cashOutSession}
-                  disabled={dealing || isCashingOut}
+                  disabled={dealing || isCashingOut || isSyncingRound}
                   className="inline-flex min-h-12 items-center gap-2 rounded-lg border border-[#d0b06e]/35 bg-[#173727] px-4 text-sm font-black text-[#fff4d8] transition hover:bg-[#214a35] disabled:cursor-not-allowed disabled:opacity-55"
                 >
                   {isCashingOut ? (isChinese ? "离桌中..." : "Cashing out...") : isChinese ? "带走筹码" : "Cash out"}

--- a/components/blackjack-table-page.tsx
+++ b/components/blackjack-table-page.tsx
@@ -15,6 +15,7 @@ import { useLanguage } from "@/hooks/use-language"
 import { type Language } from "@/lib/home-content"
 import { type CasinoTableEntry } from "@/lib/game-catalog"
 import { type MemberGameProgress, type MemberTableSession } from "@/lib/member-data"
+import { recordClientGameRound } from "@/lib/member-round-client"
 import { cashOutClientTableSession, openClientTableSession } from "@/lib/table-session-client"
 import { cn } from "@/lib/utils"
 
@@ -398,47 +399,36 @@ async function persistBlackjackProgress(
   idempotencyKey: string,
   tableSessionId?: string,
 ) {
-  const response = await fetch("/api/member/progress", {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({
-      gameSlug: entry.slug,
-      outcome: delta > 0 ? "win" : delta < 0 ? "loss" : "push",
-      delta,
-      bankroll,
-      summary,
-      idempotencyKey,
-      tableSessionId,
+  return recordClientGameRound({
+    gameSlug: entry.slug,
+    outcome: delta > 0 ? "win" : delta < 0 ? "loss" : "push",
+    delta,
+    bankroll,
+    summary,
+    idempotencyKey,
+    tableSessionId,
+    totalStake,
+    betSnapshot: {
+      hands: hands.map((hand) => ({
+        label: hand.label,
+        bet: hand.bet,
+        doubled: hand.doubled,
+        fromSplit: hand.fromSplit,
+      })),
+      insuranceBet,
       totalStake,
-      betSnapshot: {
-        hands: hands.map((hand) => ({
-          label: hand.label,
-          bet: hand.bet,
-          doubled: hand.doubled,
-          fromSplit: hand.fromSplit,
-        })),
-        insuranceBet,
-        totalStake,
-      },
-      resultSnapshot: {
-        dealerCards,
-        hands: hands.map((hand) => ({
-          label: hand.label,
-          cards: hand.cards,
-          resultLabel: hand.resultLabel,
-          busted: hand.busted,
-          naturalBlackjack: hand.naturalBlackjack,
-        })),
-      },
-    }),
-  }).catch(() => null)
-
-  if (!response?.ok) {
-    return null
-  }
-
-  const payload = (await response.json().catch(() => null)) as { progress?: { bankroll?: unknown } } | null
-  return typeof payload?.progress?.bankroll === "number" ? payload.progress.bankroll : null
+    },
+    resultSnapshot: {
+      dealerCards,
+      hands: hands.map((hand) => ({
+        label: hand.label,
+        cards: hand.cards,
+        resultLabel: hand.resultLabel,
+        busted: hand.busted,
+        naturalBlackjack: hand.naturalBlackjack,
+      })),
+    },
+  })
 }
 
 export function BlackjackTablePage({
@@ -456,6 +446,12 @@ export function BlackjackTablePage({
 }) {
   const [language] = useLanguage(defaultLanguage)
   const isChinese = language === "zh"
+  const buyInWalletLabel = isChinese ? "主钱包余额" : "Main wallet"
+  const tableChipsLabel = isChinese ? "桌台筹码（随输赢变化）" : "Table chips (changes each hand)"
+  const mainWalletNote = isChinese ? "主钱包（买入/离桌时变化）" : "Main wallet (buy-in/cash-out only)"
+  const buyInHint = isChinese
+    ? "主钱包只在买入和离桌时变化；每手牌输赢会先结算到本桌筹码。"
+    : "Your wallet changes on buy-in and cash-out. Each hand settles into table chips first."
   const initialBankroll = initialTableSession?.chipBalance ?? 0
   const [bankroll, setBankroll] = useState(initialBankroll)
   const [walletBalance, setWalletBalance] = useState(initialWalletBalance)
@@ -463,6 +459,7 @@ export function BlackjackTablePage({
   const [buyInAmount, setBuyInAmount] = useState(100)
   const [isOpeningSession, setIsOpeningSession] = useState(false)
   const [isCashingOut, setIsCashingOut] = useState(false)
+  const [isSyncingRound, setIsSyncingRound] = useState(false)
   const [stake, setStake] = useState(50)
   const [chips, setChips] = useState(defaultChips)
   const [initialBankrollInput, setInitialBankrollInput] = useState(String(initialBankroll))
@@ -634,7 +631,7 @@ export function BlackjackTablePage({
     setMessage(isChinese ? "正在带走筹码并结算回钱包..." : "Cashing out table chips to your wallet...")
 
     try {
-      const result = await cashOutClientTableSession(tableSession.id, "blackjack-cash-out")
+      const result = await cashOutClientTableSession(tableSession.id, "blackjack-cash-out", tableSession.chipBalance)
 
       setTableSession(null)
       setBankroll(0)
@@ -686,24 +683,34 @@ export function BlackjackTablePage({
     setPhase("done")
     setMessage(settled.message)
     persistLocal(settled.balance, settled.stats)
-    void persistBlackjackProgress(
-      entry,
-      settled.roundDelta,
-      settled.balance,
-      settled.message,
-      settled.totalStake,
-      settled.hands,
-      currentDealer,
-      currentInsuranceBet,
-      `blackjack-${entry.slug}-${Date.now()}-${Math.random().toString(16).slice(2)}`,
-      activeTableSession.id,
-    ).then((serverBankroll) => {
-      if (typeof serverBankroll === "number") {
-        setBankroll(serverBankroll)
-        setTableSession((current) => current ? { ...current, chipBalance: serverBankroll } : current)
-        persistLocal(serverBankroll, settled.stats)
+    setIsSyncingRound(true)
+    void (async () => {
+      try {
+        const serverBankroll = await persistBlackjackProgress(
+          entry,
+          settled.roundDelta,
+          settled.balance,
+          settled.message,
+          settled.totalStake,
+          settled.hands,
+          currentDealer,
+          currentInsuranceBet,
+          `blackjack-${entry.slug}-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+          activeTableSession.id,
+        )
+
+        if (typeof serverBankroll === "number") {
+          setBankroll(serverBankroll)
+          setTableSession((current) => current ? { ...current, chipBalance: serverBankroll } : current)
+          persistLocal(serverBankroll, settled.stats)
+        }
+      } catch (error) {
+        console.error("blackjack round sync failed", error)
+      } finally {
+        setIsSyncingRound(false)
+        setPhase("done")
       }
-    })
+    })()
   }
 
   function dealerPlay(
@@ -1125,12 +1132,10 @@ export function BlackjackTablePage({
                   {isChinese ? "先从钱包买入本桌筹码" : "Buy chips before joining this table"}
                 </h2>
                 <p className="mt-2 max-w-2xl text-sm leading-6 text-[#cbbd91]">
-                  {isChinese
-                    ? "本桌下注只使用桌台筹码，离桌时再把剩余筹码带回钱包。"
-                    : "Bets use table chips, then remaining chips return to your wallet when you cash out."}
+                  {buyInHint}
                 </p>
                 <p className="mt-3 text-sm font-black text-[#f4d18a]">
-                  {isChinese ? "钱包余额" : "Wallet"} {formatMoney(walletBalance)}
+                  {buyInWalletLabel} {formatMoney(walletBalance)}
                 </p>
               </div>
 
@@ -1191,19 +1196,19 @@ export function BlackjackTablePage({
                 <p className="text-sm font-black uppercase tracking-[0.16em] text-[#d0b06e]">
                   {isChinese ? "资金与操作" : "Bankroll & Actions"}
                 </p>
-                <p className="mt-3 text-sm text-[#cbbd91]">{isChinese ? "桌台筹码" : "Table chips"}</p>
+                <p className="mt-3 text-sm text-[#cbbd91]">{tableChipsLabel}</p>
                 <p className="text-5xl font-black leading-none text-[#f4d18a] md:text-6xl">
                   {formatMoney(bankroll)}
                 </p>
                 <p className="mt-2 text-xs font-bold text-[#cbbd91]">
-                  {isChinese ? "钱包" : "Wallet"} {formatMoney(walletBalance)}
+                  {mainWalletNote} {formatMoney(walletBalance)}
                 </p>
               </div>
               {tableSession ? (
                 <button
                   type="button"
                   onClick={cashOutSession}
-                  disabled={isCashingOut || dealing || (phase !== "idle" && phase !== "done")}
+                  disabled={isCashingOut || isSyncingRound || dealing || (phase !== "idle" && phase !== "done")}
                   className="inline-flex min-h-12 items-center rounded-lg border border-[#d0b06e]/35 bg-[#173727] px-4 text-sm font-black text-[#fff4d8] transition hover:bg-[#214a35] disabled:cursor-not-allowed disabled:opacity-55"
                 >
                   {isCashingOut ? (isChinese ? "离桌中..." : "Cashing out...") : isChinese ? "带走筹码" : "Cash out"}

--- a/components/dice-table-page.tsx
+++ b/components/dice-table-page.tsx
@@ -8,6 +8,7 @@ import { useLanguage } from "@/hooks/use-language"
 import { type Language } from "@/lib/home-content"
 import { type CasinoTableEntry } from "@/lib/game-catalog"
 import { type MemberGameProgress, type MemberTableSession } from "@/lib/member-data"
+import { recordClientGameRound } from "@/lib/member-round-client"
 import { cashOutClientTableSession, openClientTableSession } from "@/lib/table-session-client"
 import { cn } from "@/lib/utils"
 
@@ -222,36 +223,25 @@ async function persistDiceProgress(
   bankroll: number,
   tableSessionId?: string,
 ) {
-  const response = await fetch("/api/member/progress", {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({
-      gameSlug: entry.slug,
-      outcome: record.delta > 0 ? "win" : record.delta < 0 ? "loss" : "push",
-      delta: record.delta,
-      bankroll,
-      summary: `${record.dice.join("+")}=${record.sum}; ${formatDelta(record.delta)}`,
-      idempotencyKey: record.id,
-      tableSessionId,
+  return recordClientGameRound({
+    gameSlug: entry.slug,
+    outcome: record.delta > 0 ? "win" : record.delta < 0 ? "loss" : "push",
+    delta: record.delta,
+    bankroll,
+    summary: `${record.dice.join("+")}=${record.sum}; ${formatDelta(record.delta)}`,
+    idempotencyKey: record.id,
+    tableSessionId,
+    totalStake: record.totalStake,
+    betSnapshot: {
+      bets: record.bets,
       totalStake: record.totalStake,
-      betSnapshot: {
-        bets: record.bets,
-        totalStake: record.totalStake,
-      },
-      resultSnapshot: {
-        dice: record.dice,
-        sum: record.sum,
-        triple: record.triple,
-      },
-    }),
-  }).catch(() => null)
-
-  if (!response?.ok) {
-    return null
-  }
-
-  const payload = (await response.json().catch(() => null)) as { progress?: { bankroll?: unknown } } | null
-  return typeof payload?.progress?.bankroll === "number" ? payload.progress.bankroll : null
+    },
+    resultSnapshot: {
+      dice: record.dice,
+      sum: record.sum,
+      triple: record.triple,
+    },
+  })
 }
 
 export function DiceTablePage({
@@ -269,6 +259,12 @@ export function DiceTablePage({
 }) {
   const [language] = useLanguage(defaultLanguage)
   const isChinese = language === "zh"
+  const buyInWalletLabel = isChinese ? "主钱包余额" : "Main wallet"
+  const tableChipsLabel = isChinese ? "桌台筹码（随结算变化）" : "Table chips (changes each round)"
+  const mainWalletNote = isChinese ? "主钱包（买入/离桌时变化）" : "Main wallet (buy-in/cash-out only)"
+  const buyInHint = isChinese
+    ? "主钱包只在买入和离桌时变化；每次结算会先计入本桌筹码。"
+    : "Your wallet changes on buy-in and cash-out. Each round settles into table chips first."
   const defaultChips = [10, 25, 50, 100, 250]
   const initialBankroll = initialTableSession?.chipBalance ?? 0
   const [bankroll, setBankroll] = useState(initialBankroll)
@@ -277,6 +273,7 @@ export function DiceTablePage({
   const [buyInAmount, setBuyInAmount] = useState(100)
   const [isOpeningSession, setIsOpeningSession] = useState(false)
   const [isCashingOut, setIsCashingOut] = useState(false)
+  const [isSyncingRound, setIsSyncingRound] = useState(false)
   const [stake, setStake] = useState(50)
   const [chips, setChips] = useState(defaultChips)
   const [initialBankrollInput, setInitialBankrollInput] = useState(String(initialBankroll))
@@ -435,7 +432,7 @@ export function DiceTablePage({
     setSubText(isChinese ? "正在带走筹码并结算回钱包。" : "Cashing out table chips to your wallet.")
 
     try {
-      const result = await cashOutClientTableSession(tableSession.id, "dice-cash-out")
+      const result = await cashOutClientTableSession(tableSession.id, "dice-cash-out", tableSession.chipBalance)
 
       setTableSession(null)
       setBankroll(0)
@@ -454,6 +451,10 @@ export function DiceTablePage({
   }
 
   function addBet(key: DiceBetKey) {
+    if (rolling) {
+      return
+    }
+
     if (!tableSession) {
       setHeadline(isChinese ? "请先买入筹码" : "Buy in first")
       setSubText(isChinese ? "先从钱包买入桌台筹码再入桌。" : "Buy in from your wallet before playing this table.")
@@ -476,10 +477,18 @@ export function DiceTablePage({
   }
 
   function setBetAmount(key: DiceBetKey, amount: number) {
+    if (rolling) {
+      return
+    }
+
     setBets((current) => ({ ...current, [key]: Math.max(0, amount) }))
   }
 
   function clearBets() {
+    if (rolling) {
+      return
+    }
+
     setBets(cloneEmptyDiceBets())
     setHeadline(isChinese ? "已清空下注" : "Bets cleared")
     setSubText(isChinese ? "余额与历史记录保留。" : "Bankroll and history were kept.")
@@ -582,17 +591,26 @@ export function DiceTablePage({
       setBankroll(nextBankroll)
       setTableSession({ ...activeTableSession, chipBalance: nextBankroll })
       setStats(nextStats)
-      setRolling(false)
       setHeadline(result.triple ? (isChinese ? "豹子出现！" : "Triple!") : isChinese ? `和值 ${result.sum}` : `Total ${result.sum}`)
       setSubText(`${result.dice.join(" + ")} = ${result.sum}，${result.detail}。`)
       persistLocal(nextBankroll, nextStats, actualDice, result.sum)
-      void persistDiceProgress(entry, record, nextBankroll, activeTableSession.id).then((serverBankroll) => {
-        if (typeof serverBankroll === "number") {
-          setBankroll(serverBankroll)
-          setTableSession((current) => current ? { ...current, chipBalance: serverBankroll } : current)
-          persistLocal(serverBankroll, nextStats, actualDice, result.sum)
+      setIsSyncingRound(true)
+      void (async () => {
+        try {
+          const serverBankroll = await persistDiceProgress(entry, record, nextBankroll, activeTableSession.id)
+
+          if (typeof serverBankroll === "number") {
+            setBankroll(serverBankroll)
+            setTableSession((current) => current ? { ...current, chipBalance: serverBankroll } : current)
+            persistLocal(serverBankroll, nextStats, actualDice, result.sum)
+          }
+        } catch (error) {
+          console.error("dice round sync failed", error)
+        } finally {
+          setIsSyncingRound(false)
+          setRolling(false)
         }
-      })
+      })()
     }, 1400)
   }
 
@@ -664,12 +682,10 @@ export function DiceTablePage({
                   {isChinese ? "先从钱包买入本桌筹码" : "Buy chips before joining this table"}
                 </h2>
                 <p className="mt-2 max-w-2xl text-sm leading-6 text-[#cbbd91]">
-                  {isChinese
-                    ? "骰子下注只使用桌台筹码，离桌时再把剩余筹码带回钱包。"
-                    : "Dice bets use table chips, then remaining chips return to your wallet when you cash out."}
+                  {buyInHint}
                 </p>
                 <p className="mt-3 text-sm font-black text-[#f4d18a]">
-                  {isChinese ? "钱包余额" : "Wallet"} {formatMoney(walletBalance)}
+                  {buyInWalletLabel} {formatMoney(walletBalance)}
                 </p>
               </div>
 
@@ -730,19 +746,19 @@ export function DiceTablePage({
                 <p className="text-sm font-black uppercase tracking-[0.16em] text-[#d0b06e]">
                   {isChinese ? "资金与掷骰" : "Bankroll & Roll"}
                 </p>
-                <p className="mt-3 text-sm text-[#cbbd91]">{isChinese ? "桌台筹码" : "Table chips"}</p>
+                <p className="mt-3 text-sm text-[#cbbd91]">{tableChipsLabel}</p>
                 <p className="text-5xl font-black leading-none text-[#f4d18a] md:text-6xl">
                   {formatMoney(bankroll)}
                 </p>
                 <p className="mt-2 text-xs font-bold text-[#cbbd91]">
-                  {isChinese ? "钱包" : "Wallet"} {formatMoney(walletBalance)}
+                  {mainWalletNote} {formatMoney(walletBalance)}
                 </p>
               </div>
               {tableSession ? (
                 <button
                   type="button"
                   onClick={cashOutSession}
-                  disabled={rolling || isCashingOut}
+                  disabled={rolling || isCashingOut || isSyncingRound}
                   className="inline-flex min-h-12 items-center rounded-lg border border-[#d0b06e]/35 bg-[#173727] px-4 text-sm font-black text-[#fff4d8] transition hover:bg-[#214a35] disabled:cursor-not-allowed disabled:opacity-55"
                 >
                   {isCashingOut ? (isChinese ? "离桌中..." : "Cashing out...") : isChinese ? "带走筹码" : "Cash out"}
@@ -944,13 +960,15 @@ export function DiceTablePage({
                         min={0}
                         step={1}
                         value={bets[bet.key]}
+                        disabled={rolling}
                         onChange={(event) => setBetAmount(bet.key, clampInt(event.target.value, 0))}
-                        className="h-9 w-24 rounded-lg border border-[#d0b06e]/35 bg-black/25 px-3 text-sm font-black text-[#fff4d8]"
+                        className="h-9 w-24 rounded-lg border border-[#d0b06e]/35 bg-black/25 px-3 text-sm font-black text-[#fff4d8] disabled:cursor-not-allowed disabled:opacity-55"
                       />
                       <button
                         type="button"
+                        disabled={rolling}
                         onClick={() => setBetAmount(bet.key, 0)}
-                        className="rounded-lg border border-[#d0b06e]/35 bg-[#173727] px-3 py-2 text-xs font-black text-[#fff4d8]"
+                        className="rounded-lg border border-[#d0b06e]/35 bg-[#173727] px-3 py-2 text-xs font-black text-[#fff4d8] disabled:cursor-not-allowed disabled:opacity-55"
                       >
                         {isChinese ? "清除" : "Clear"}
                       </button>

--- a/components/player-home-page.tsx
+++ b/components/player-home-page.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import Link from "next/link"
+import { useEffect, useState } from "react"
 import { Diamond, Dice1, ShieldCheck, Spade, Target, Trophy } from "lucide-react"
 
 import { GameCard } from "@/components/game-card"
@@ -65,6 +66,8 @@ type RecentActivity = HomeActivityItem & {
   gameSlug?: string
 }
 
+type HomeMemberOverview = PlayerHomePageProps["initialMemberOverview"]
+
 function formatMoney(value: number) {
   return value.toLocaleString("en-US", {
     style: "currency",
@@ -84,18 +87,58 @@ function isToday(value: string) {
   )
 }
 
+function buildTodayNet(member: PlayerHomePageProps["initialMemberOverview"]) {
+  const gamingLedgerSources = new Set(["game_round", "table_buy_in", "table_cash_out"])
+  const todayGamingLedger = member.walletLedger.filter(
+    (entry) => gamingLedgerSources.has(entry.source) && isToday(entry.createdAt),
+  )
+
+  if (todayGamingLedger.length > 0) {
+    return todayGamingLedger.reduce((sum, entry) => sum + entry.amount, 0)
+  }
+
+  return member.gameRounds
+    .filter((round) => isToday(round.createdAt))
+    .reduce((sum, round) => sum + round.delta, 0)
+}
+
 function buildMemberStats(
   language: "zh" | "en",
   member: PlayerHomePageProps["initialMemberOverview"],
 ): HomeStatItem[] {
-  const plays = member.progress.reduce((sum, progress) => sum + progress.plays, 0)
-  const wins = member.progress.reduce((sum, progress) => sum + progress.wins, 0)
-  const currentStreak = Math.max(0, ...member.progress.map((progress) => progress.streak))
-  const bestStreak = Math.max(0, ...member.progress.map((progress) => progress.bestStreak))
+  const sortedRounds = [...member.gameRounds].sort(
+    (left, right) => new Date(right.createdAt).getTime() - new Date(left.createdAt).getTime(),
+  )
+  const chronologicalRounds = [...sortedRounds].reverse()
+  const plays = sortedRounds.length || member.progress.reduce((sum, progress) => sum + progress.plays, 0)
+  const wins = sortedRounds.length
+    ? sortedRounds.filter((round) => round.outcome === "win" || round.delta > 0).length
+    : member.progress.reduce((sum, progress) => sum + progress.wins, 0)
+  const currentStreak = sortedRounds.length
+    ? sortedRounds.findIndex((round) => !(round.outcome === "win" || round.delta > 0))
+    : Math.max(0, ...member.progress.map((progress) => progress.streak))
+  let bestStreakFromRounds = 0
+  let runningStreak = 0
+
+  for (const round of chronologicalRounds) {
+    if (round.outcome === "win" || round.delta > 0) {
+      runningStreak += 1
+      bestStreakFromRounds = Math.max(bestStreakFromRounds, runningStreak)
+    } else if (round.outcome === "loss" || round.delta < 0) {
+      runningStreak = 0
+    }
+  }
+
+  const bestStreak = sortedRounds.length
+    ? bestStreakFromRounds
+    : Math.max(0, ...member.progress.map((progress) => progress.bestStreak))
+  const trackedTables = new Set([
+    ...member.progress.map((progress) => "gameSlug" in progress ? String(progress.gameSlug) : ""),
+    ...member.gameRounds.map((round) => round.gameSlug),
+  ].filter(Boolean)).size
   const winRate = plays > 0 ? Math.round((wins / plays) * 100) : 0
-  const todayNet = member.gameRounds
-    .filter((round) => isToday(round.createdAt))
-    .reduce((sum, round) => sum + round.delta, 0)
+  const todayNet = buildTodayNet(member)
+  const normalizedCurrentStreak = currentStreak < 0 ? sortedRounds.length : currentStreak
 
   if (language === "zh") {
     return [
@@ -117,15 +160,15 @@ function buildMemberStats(
         key: "recent",
         label: "最近游玩",
         value: `${plays} 局`,
-        subtext: member.progress.length > 0 ? `${member.progress.length} 个桌台有记录` : "开始第一局后自动更新",
+        subtext: trackedTables > 0 ? `${trackedTables} 个桌台有记录` : "开始第一局后自动更新",
         trend: "neutral",
       },
       {
         key: "streak",
         label: "连胜记录",
-        value: `${currentStreak} 局`,
-        subtext: bestStreak > currentStreak ? `个人最好 ${bestStreak} 局` : "当前为个人最好",
-        trend: currentStreak > 0 ? "up" : "neutral",
+        value: `${normalizedCurrentStreak} 局`,
+        subtext: bestStreak > normalizedCurrentStreak ? `个人最好 ${bestStreak} 局` : "当前为个人最好",
+        trend: normalizedCurrentStreak > 0 ? "up" : "neutral",
       },
     ]
   }
@@ -149,15 +192,15 @@ function buildMemberStats(
       key: "recent",
       label: "Recent Play",
       value: `${plays}`,
-      subtext: member.progress.length > 0 ? `${member.progress.length} tables tracked` : "Updates after your first round",
+      subtext: trackedTables > 0 ? `${trackedTables} tables tracked` : "Updates after your first round",
       trend: "neutral",
     },
     {
       key: "streak",
       label: "Streak",
-      value: `${currentStreak}`,
-      subtext: bestStreak > currentStreak ? `Best streak ${bestStreak}` : "Current personal best",
-      trend: currentStreak > 0 ? "up" : "neutral",
+      value: `${normalizedCurrentStreak}`,
+      subtext: bestStreak > normalizedCurrentStreak ? `Best streak ${bestStreak}` : "Current personal best",
+      trend: normalizedCurrentStreak > 0 ? "up" : "neutral",
     },
   ]
 }
@@ -205,7 +248,7 @@ function titleForGameSlug(slug: string | undefined, language: "zh" | "en") {
     return language === "zh" ? "会员牌局" : "Member Round"
   }
 
-  return game.title
+  return language === "zh" ? game.titleZh : game.title
 }
 
 function resultForLedgerEntry(entry: PlayerHomePageProps["initialMemberOverview"]["walletLedger"][number], language: "zh" | "en") {
@@ -298,8 +341,52 @@ function buildWeeklyProfitBoard(
 
 export function PlayerHomePage({ initialLanguage, initialMemberName, initialMemberOverview }: PlayerHomePageProps) {
   const [language] = useLanguage(initialLanguage)
+  const [memberOverview, setMemberOverview] = useState<HomeMemberOverview>(initialMemberOverview)
   const isAuthenticated = true
   const authHref = "/login"
+
+  useEffect(() => {
+    let active = true
+
+    async function refreshMemberOverview() {
+      const response = await fetch("/api/member/me", {
+        cache: "no-store",
+      }).catch(() => null)
+
+      if (!response?.ok) {
+        return
+      }
+
+      const payload = (await response.json().catch(() => null)) as { member?: HomeMemberOverview } | null
+
+      if (active && payload?.member) {
+        setMemberOverview(payload.member)
+      }
+    }
+
+    void refreshMemberOverview()
+
+    function handlePageShow() {
+      void refreshMemberOverview()
+    }
+
+    function handleVisibilityChange() {
+      if (document.visibilityState === "visible") {
+        void refreshMemberOverview()
+      }
+    }
+
+    window.addEventListener("pageshow", handlePageShow)
+    window.addEventListener("focus", handlePageShow)
+    document.addEventListener("visibilitychange", handleVisibilityChange)
+
+    return () => {
+      active = false
+      window.removeEventListener("pageshow", handlePageShow)
+      window.removeEventListener("focus", handlePageShow)
+      document.removeEventListener("visibilitychange", handleVisibilityChange)
+    }
+  }, [])
 
   async function handleLogout() {
     await clearMemberSession()
@@ -310,10 +397,10 @@ export function PlayerHomePage({ initialLanguage, initialMemberName, initialMemb
   const copy = getHomeCopy(language, viewerMode)
   const navItems = getNavItems(language)
   const games = getGameLinks(language)
-  const stats = buildMemberStats(language, initialMemberOverview)
+  const stats = buildMemberStats(language, memberOverview)
   const quickActions = getQuickActions(language, viewerMode)
-  const weeklyProfitBoard = buildWeeklyProfitBoard(language, initialMemberOverview)
-  const recentActivities = buildRecentActivities(language, initialMemberOverview)
+  const weeklyProfitBoard = buildWeeklyProfitBoard(language, memberOverview)
+  const recentActivities = buildRecentActivities(language, memberOverview)
   const extraTables = playableTableEntries.filter(
     (table) => table.kind === "game" && !games.some((game) => game.slug === table.slug),
   )

--- a/components/roulette-table-page.tsx
+++ b/components/roulette-table-page.tsx
@@ -8,6 +8,7 @@ import { useLanguage } from "@/hooks/use-language"
 import { type Language } from "@/lib/home-content"
 import { type CasinoTableEntry } from "@/lib/game-catalog"
 import { type MemberGameProgress, type MemberTableSession } from "@/lib/member-data"
+import { recordClientGameRound } from "@/lib/member-round-client"
 import { cashOutClientTableSession, openClientTableSession } from "@/lib/table-session-client"
 import { cn } from "@/lib/utils"
 
@@ -332,35 +333,24 @@ async function persistRouletteProgress(
   idempotencyKey: string,
   tableSessionId?: string,
 ) {
-  const response = await fetch("/api/member/progress", {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({
-      gameSlug: entry.slug,
-      outcome: delta > 0 ? "win" : delta < 0 ? "loss" : "push",
-      delta,
-      bankroll,
-      summary: `Roulette ${result} ${numberColor(result)}; ${formatDelta(delta)}`,
-      idempotencyKey,
-      tableSessionId,
+  return recordClientGameRound({
+    gameSlug: entry.slug,
+    outcome: delta > 0 ? "win" : delta < 0 ? "loss" : "push",
+    delta,
+    bankroll,
+    summary: `Roulette ${result} ${numberColor(result)}; ${formatDelta(delta)}`,
+    idempotencyKey,
+    tableSessionId,
+    totalStake,
+    betSnapshot: {
+      bets,
       totalStake,
-      betSnapshot: {
-        bets,
-        totalStake,
-      },
-      resultSnapshot: {
-        result,
-        color: numberColor(result),
-      },
-    }),
-  }).catch(() => null)
-
-  if (!response?.ok) {
-    return null
-  }
-
-  const payload = (await response.json().catch(() => null)) as { progress?: { bankroll?: unknown } } | null
-  return typeof payload?.progress?.bankroll === "number" ? payload.progress.bankroll : null
+    },
+    resultSnapshot: {
+      result,
+      color: numberColor(result),
+    },
+  })
 }
 
 export function RouletteTablePage({
@@ -378,6 +368,12 @@ export function RouletteTablePage({
 }) {
   const [language] = useLanguage(defaultLanguage)
   const isChinese = language === "zh"
+  const buyInWalletLabel = isChinese ? "主钱包余额" : "Main wallet"
+  const tableChipsLabel = isChinese ? "桌台筹码（随结算变化）" : "Table chips (changes each round)"
+  const mainWalletNote = isChinese ? "主钱包（买入/离桌时变化）" : "Main wallet (buy-in/cash-out only)"
+  const buyInHint = isChinese
+    ? "主钱包只在买入和离桌时变化；每次结算会先计入本桌筹码。"
+    : "Your wallet changes on buy-in and cash-out. Each round settles into table chips first."
   const defaultChips = [10, 25, 50, 100, 250]
   const canvasRef = useRef<HTMLCanvasElement | null>(null)
   const animationFrameRef = useRef<number | null>(null)
@@ -393,6 +389,7 @@ export function RouletteTablePage({
   const [buyInAmount, setBuyInAmount] = useState(100)
   const [isOpeningSession, setIsOpeningSession] = useState(false)
   const [isCashingOut, setIsCashingOut] = useState(false)
+  const [isSyncingRound, setIsSyncingRound] = useState(false)
   const [stake, setStake] = useState(50)
   const [chips, setChips] = useState(defaultChips)
   const [initialBankrollInput, setInitialBankrollInput] = useState(String(initialBankroll))
@@ -574,7 +571,7 @@ export function RouletteTablePage({
     setMessage(isChinese ? "正在带走筹码并结算回钱包..." : "Cashing out table chips to your wallet...")
 
     try {
-      const result = await cashOutClientTableSession(tableSession.id, "roulette-cash-out")
+      const result = await cashOutClientTableSession(tableSession.id, "roulette-cash-out", tableSession.chipBalance)
 
       setTableSession(null)
       setBankroll(0)
@@ -813,6 +810,7 @@ export function RouletteTablePage({
       setSpinProgress(96)
 
       settleTimeoutRef.current = window.setTimeout(() => {
+        void (async () => {
         const delta = bets.reduce((sum, bet) => sum + payoutOne(bet, settledResult), 0)
         const nextBankroll = bankroll + delta
         const nextStats: RouletteStats = {
@@ -828,29 +826,38 @@ export function RouletteTablePage({
         setTableSession({ ...activeTableSession, chipBalance: nextBankroll })
         setStats(nextStats)
         setSpinProgress(100)
-        setSpinning(false)
         setMessage(
           isChinese
             ? `开出 ${settledResult}（${numberColor(settledResult) === "green" ? "绿" : numberColor(settledResult) === "red" ? "红" : "黑"}），本轮 ${formatDelta(delta)}。`
             : `Landed on ${settledResult} ${numberColor(settledResult)}, round ${formatDelta(delta)}.`,
         )
         persistLocal(nextBankroll, nextStats, settledResult, finalWheelAngle)
-        void persistRouletteProgress(
-          entry,
-          settledResult,
-          delta,
-          nextBankroll,
-          preview.totalStake,
-          bets,
-          `roulette-${entry.slug}-${Date.now()}-${Math.random().toString(16).slice(2)}`,
-          activeTableSession.id,
-        ).then((serverBankroll) => {
+        setIsSyncingRound(true)
+
+        try {
+          const serverBankroll = await persistRouletteProgress(
+            entry,
+            settledResult,
+            delta,
+            nextBankroll,
+            preview.totalStake,
+            bets,
+            `roulette-${entry.slug}-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+            activeTableSession.id,
+          )
+
           if (typeof serverBankroll === "number") {
             setBankroll(serverBankroll)
             setTableSession((current) => current ? { ...current, chipBalance: serverBankroll } : current)
             persistLocal(serverBankroll, nextStats, settledResult, finalWheelAngle)
           }
-        })
+        } catch (error) {
+          console.error("roulette round sync failed", error)
+        } finally {
+          setIsSyncingRound(false)
+          setSpinning(false)
+        }
+        })()
       }, settleDelay)
     }
 
@@ -931,12 +938,10 @@ export function RouletteTablePage({
                   {isChinese ? "先从钱包买入本桌筹码" : "Buy chips before joining this table"}
                 </h2>
                 <p className="mt-2 max-w-2xl text-sm leading-6 text-[#cbbd91]">
-                  {isChinese
-                    ? "轮盘下注只使用桌台筹码，离桌时再把剩余筹码带回钱包。"
-                    : "Roulette bets use table chips, then remaining chips return to your wallet when you cash out."}
+                  {buyInHint}
                 </p>
                 <p className="mt-3 text-sm font-black text-[#f4d18a]">
-                  {isChinese ? "钱包余额" : "Wallet"} {formatMoney(walletBalance)}
+                  {buyInWalletLabel} {formatMoney(walletBalance)}
                 </p>
               </div>
 
@@ -997,19 +1002,19 @@ export function RouletteTablePage({
                 <p className="text-sm font-black uppercase tracking-[0.16em] text-[#d0b06e]">
                   {isChinese ? "资金与旋转" : "Bankroll & Spin"}
                 </p>
-                <p className="mt-3 text-sm text-[#cbbd91]">{isChinese ? "桌台筹码" : "Table chips"}</p>
+                <p className="mt-3 text-sm text-[#cbbd91]">{tableChipsLabel}</p>
                 <p className="text-5xl font-black leading-none text-[#f4d18a] md:text-6xl">
                   {formatMoney(bankroll)}
                 </p>
                 <p className="mt-2 text-xs font-bold text-[#cbbd91]">
-                  {isChinese ? "钱包" : "Wallet"} {formatMoney(walletBalance)}
+                  {mainWalletNote} {formatMoney(walletBalance)}
                 </p>
               </div>
               {tableSession ? (
                 <button
                   type="button"
                   onClick={cashOutSession}
-                  disabled={spinning || isCashingOut}
+                  disabled={spinning || isCashingOut || isSyncingRound}
                   className="inline-flex min-h-12 items-center rounded-lg border border-[#d0b06e]/35 bg-[#173727] px-4 text-sm font-black text-[#fff4d8] transition hover:bg-[#214a35] disabled:cursor-not-allowed disabled:opacity-55"
                 >
                   {isCashingOut ? (isChinese ? "离桌中..." : "Cashing out...") : isChinese ? "带走筹码" : "Cash out"}

--- a/lib/member-data.ts
+++ b/lib/member-data.ts
@@ -16,6 +16,7 @@ import {
   isSupabaseAuthConfigured,
   readSessionToken,
 } from "@/lib/server-auth"
+import { getPlayableTable } from "@/lib/game-catalog"
 
 type CookieStore = Awaited<ReturnType<typeof cookies>>
 
@@ -163,6 +164,15 @@ export interface MemberPurchase {
   creditedAt: string | null
 }
 
+export interface MemberProduct {
+  id: string
+  title: string
+  titleZh: string
+  amount: number
+  credits: number
+  badge: string
+}
+
 export interface WalletEntryInput {
   source: WalletLedgerSource
   amount: number
@@ -219,6 +229,45 @@ const LOCAL_STATE_PROGRESS_LIMIT = 4
 const LOCAL_STATE_EVENT_LIMIT = 3
 const LOCAL_STATE_ROUND_LIMIT = 12
 const LOCAL_STATE_TABLE_SESSION_LIMIT = 8
+const MEMBER_EVENT_KINDS = new Set([
+  "login_success",
+  "session_recovered",
+  "game_start",
+  "round_complete",
+  "wallet_update",
+  "ad_reward_start",
+  "ad_reward_complete",
+  "purchase_attempt",
+  "purchase_success",
+  "purchase_failed",
+  "save_recovered",
+])
+const MEMBER_PRODUCTS: MemberProduct[] = [
+  {
+    id: "starter_credits",
+    title: "Starter Credits",
+    titleZh: "入门筹码包",
+    amount: 1.99,
+    credits: 1200,
+    badge: "Starter",
+  },
+  {
+    id: "table_night",
+    title: "Table Night Pack",
+    titleZh: "牌桌夜场包",
+    amount: 4.99,
+    credits: 3600,
+    badge: "Popular",
+  },
+  {
+    id: "resort_weekend",
+    title: "Resort Weekend Pack",
+    titleZh: "度假周末包",
+    amount: 9.99,
+    credits: 8200,
+    badge: "Best value",
+  },
+]
 const LOCAL_STATE_SUMMARY_LIMIT = 120
 
 function nowIso() {
@@ -981,6 +1030,10 @@ export async function cashOutTableSession(
 
   const patchBody = body && typeof body === "object" ? (body as Record<string, unknown>) : {}
   const idempotencyKey = normalizeIdempotencyKey(patchBody.idempotencyKey, `table-cash-out-${sessionId}`)
+  const expectedChipBalance =
+    typeof patchBody.expectedChipBalance === "number"
+      ? Math.min(100000000, Math.max(0, normalizeMoney(patchBody.expectedChipBalance)))
+      : null
 
   if (auth.source === "supabase") {
     if (!auth.session.userId) {
@@ -988,6 +1041,23 @@ export async function cashOutTableSession(
     }
 
     const serviceSupabase = createSupabaseServiceClient()
+
+    if (expectedChipBalance !== null) {
+      const { error: syncError } = await serviceSupabase
+        .from("member_table_sessions")
+        .update({
+          chip_balance: expectedChipBalance,
+          updated_at: nowIso(),
+        })
+        .eq("id", sessionId)
+        .eq("user_id", auth.session.userId)
+        .eq("status", "active")
+
+      if (syncError) {
+        throw new Error(syncError.message)
+      }
+    }
+
     const { data, error } = await serviceSupabase.rpc("cash_out_member_table_session", {
       p_user_id: auth.session.userId,
       p_session_id: sessionId,
@@ -1027,16 +1097,25 @@ export async function cashOutTableSession(
     }
   }
 
+  const reconciledTableSession =
+    expectedChipBalance === null
+      ? tableSession
+      : {
+          ...tableSession,
+          chipBalance: expectedChipBalance,
+          updatedAt: nowIso(),
+        }
+
   const walletEntry = applyLocalWalletEntry(auth, cookieStore, response, {
     source: "table_cash_out",
-    amount: tableSession.chipBalance,
-    referenceId: tableSession.id,
+    amount: reconciledTableSession.chipBalance,
+    referenceId: reconciledTableSession.id,
     idempotencyKey,
-    metadata: { gameSlug: tableSession.gameSlug, tableSessionId: tableSession.id },
+    metadata: { gameSlug: reconciledTableSession.gameSlug, tableSessionId: reconciledTableSession.id },
   })
   const closedAt = walletEntry.createdAt
   const nextSession: MemberTableSession = {
-    ...tableSession,
+    ...reconciledTableSession,
     status: "cashed_out",
     chipBalance: 0,
     cashOutLedgerId: walletEntry.ledgerId,
@@ -1109,6 +1188,20 @@ async function settleSupabaseTableSessionRound(
   })
 
   if (error) {
+    if (error.message.includes("settle_member_table_session_round") || error.message.includes("schema cache")) {
+      return settleSupabaseTableSessionRoundDirect(auth, {
+        sessionId,
+        gameSlug,
+        outcome,
+        delta,
+        totalStake,
+        summary,
+        betSnapshot,
+        resultSnapshot,
+        idempotencyKey,
+      })
+    }
+
     throw new Error(error.message)
   }
 
@@ -1132,6 +1225,187 @@ async function settleSupabaseTableSessionRound(
     progress: toProgress(progressPayload as Record<string, unknown>),
     tableSession: toTableSession(sessionPayload as Record<string, unknown>),
     idempotent: payload.idempotent === true,
+  }
+}
+
+async function settleSupabaseTableSessionRoundDirect(
+  auth: AuthenticatedMember,
+  {
+    sessionId,
+    gameSlug,
+    outcome,
+    delta,
+    totalStake,
+    summary,
+    betSnapshot,
+    resultSnapshot,
+    idempotencyKey,
+  }: {
+    sessionId: string
+    gameSlug: string
+    outcome: ProgressOutcome
+    delta: number
+    totalStake: number
+    summary: string
+    betSnapshot: Record<string, unknown>
+    resultSnapshot: Record<string, unknown>
+    idempotencyKey: string | null
+  },
+) {
+  const userId = auth.session.userId
+
+  if (!userId) {
+    throw new Error("Supabase member session is missing a user id.")
+  }
+
+  const serviceSupabase = createSupabaseServiceClient()
+
+  if (idempotencyKey) {
+    const existingRound = await findSupabaseRoundByIdempotencyKey(userId, idempotencyKey)
+
+    if (existingRound) {
+      const [{ data: existingSession }, { data: existingProgress }] = await Promise.all([
+        serviceSupabase
+          .from("member_table_sessions")
+          .select("*")
+          .eq("id", existingRound.tableSessionId ?? sessionId)
+          .eq("user_id", userId)
+          .maybeSingle(),
+        serviceSupabase
+          .from("member_game_progress")
+          .select("*")
+          .eq("user_id", userId)
+          .eq("game_slug", existingRound.gameSlug)
+          .maybeSingle(),
+      ])
+
+      if (existingSession && existingProgress) {
+        return {
+          progress: toProgress(existingProgress),
+          tableSession: toTableSession(existingSession),
+          idempotent: true,
+        }
+      }
+    }
+  }
+
+  const { data: sessionData, error: sessionError } = await serviceSupabase
+    .from("member_table_sessions")
+    .select("*")
+    .eq("id", sessionId)
+    .eq("user_id", userId)
+    .eq("status", "active")
+    .maybeSingle()
+
+  if (sessionError) {
+    throw new Error(sessionError.message)
+  }
+
+  if (!sessionData) {
+    throw new Error("Active table session was not found.")
+  }
+
+  const tableSession = toTableSession(sessionData)
+
+  if (tableSession.gameSlug !== gameSlug) {
+    throw new Error("Table session game does not match round game.")
+  }
+
+  const chipBalanceBefore = tableSession.chipBalance
+  const chipBalanceAfter = Math.round((chipBalanceBefore + delta) * 100) / 100
+
+  if (chipBalanceAfter < 0) {
+    throw new Error("Insufficient table chips.")
+  }
+
+  const playedAt = nowIso()
+  const { data: updatedSession, error: updateSessionError } = await serviceSupabase
+    .from("member_table_sessions")
+    .update({
+      chip_balance: chipBalanceAfter,
+      updated_at: playedAt,
+    })
+    .eq("id", sessionId)
+    .eq("user_id", userId)
+    .eq("status", "active")
+    .select("*")
+    .single()
+
+  if (updateSessionError) {
+    throw new Error(updateSessionError.message)
+  }
+
+  const { data: existingProgress, error: existingProgressError } = await serviceSupabase
+    .from("member_game_progress")
+    .select("*")
+    .eq("user_id", userId)
+    .eq("game_slug", gameSlug)
+    .maybeSingle()
+
+  if (existingProgressError) {
+    throw new Error(existingProgressError.message)
+  }
+
+  const current = existingProgress ? toProgress(existingProgress) : null
+  const streak = outcome === "win" ? (current?.streak ?? 0) + 1 : outcome === "loss" ? 0 : current?.streak ?? 0
+  const { data: progressData, error: progressError } = await serviceSupabase
+    .from("member_game_progress")
+    .upsert({
+      user_id: userId,
+      game_slug: gameSlug,
+      plays: (current?.plays ?? 0) + 1,
+      wins: (current?.wins ?? 0) + (outcome === "win" ? 1 : 0),
+      losses: (current?.losses ?? 0) + (outcome === "loss" ? 1 : 0),
+      streak,
+      best_streak: Math.max(current?.bestStreak ?? 0, streak),
+      bankroll: chipBalanceAfter,
+      last_result: outcome,
+      last_delta: delta,
+      last_summary: summary,
+      last_played_at: playedAt,
+    })
+    .select("*")
+    .single()
+
+  if (progressError) {
+    throw new Error(progressError.message)
+  }
+
+  await insertSupabaseGameRound({
+    userId,
+    gameSlug,
+    tableSessionId: sessionId,
+    outcome,
+    delta,
+    totalStake,
+    chipBalanceBefore,
+    chipBalanceAfter,
+    summary,
+    betSnapshot,
+    resultSnapshot: {
+      ...resultSnapshot,
+      tableSessionId: sessionId,
+      chipBalanceBefore,
+      chipBalanceAfter,
+    },
+    idempotencyKey,
+  })
+
+  const { error: eventError } = await serviceSupabase.from("member_events").insert({
+    user_id: userId,
+    kind: "round_complete",
+    title: `${gameSlug} ${outcome}`,
+    detail: summary,
+  })
+
+  if (eventError) {
+    throw new Error(eventError.message)
+  }
+
+  return {
+    progress: toProgress(progressData),
+    tableSession: toTableSession(updatedSession),
+    idempotent: false,
   }
 }
 
@@ -1504,6 +1778,587 @@ export async function applyTestWalletTopUp(cookieStore: CookieStore, response: N
   return walletEntry
 }
 
+function normalizeEventKind(value: unknown) {
+  const kind = typeof value === "string" ? value.trim().slice(0, 80) : ""
+
+  return MEMBER_EVENT_KINDS.has(kind) ? kind : "wallet_update"
+}
+
+function normalizeAdRewardPlacement(value: unknown): AdRewardPlacement {
+  return value === "loss_recovery" || value === "lobby_reward" ? value : "daily_bonus"
+}
+
+function rewardAmountForPlacement(placement: AdRewardPlacement) {
+  return placement === "loss_recovery" ? 250 : placement === "lobby_reward" ? 100 : 150
+}
+
+function findMemberProduct(productId: unknown) {
+  const id = typeof productId === "string" ? productId.trim() : ""
+
+  return MEMBER_PRODUCTS.find((product) => product.id === id) ?? null
+}
+
+export function listMemberProducts() {
+  return MEMBER_PRODUCTS
+}
+
+export async function recordMemberEvent(cookieStore: CookieStore, response: NextResponse, body: unknown) {
+  const auth = await getAuthenticatedMember(cookieStore, response)
+
+  if (!auth) {
+    return null
+  }
+
+  const patchBody = body && typeof body === "object" ? (body as Record<string, unknown>) : {}
+  const createdAt = nowIso()
+  const event: MemberEvent = {
+    id: `${createdAt}-${Math.random().toString(16).slice(2)}`,
+    kind: normalizeEventKind(patchBody.kind),
+    title: typeof patchBody.title === "string" && patchBody.title.trim() ? patchBody.title.trim().slice(0, 80) : "Member event",
+    detail: typeof patchBody.detail === "string" ? patchBody.detail.trim().slice(0, LOCAL_STATE_SUMMARY_LIMIT) : "",
+    createdAt,
+  }
+
+  if (auth.source === "supabase") {
+    if (!auth.session.userId) {
+      throw new Error("Supabase member session is missing a user id.")
+    }
+
+    const serviceSupabase = createSupabaseServiceClient()
+    const { data, error } = await serviceSupabase
+      .from("member_events")
+      .insert({
+        user_id: auth.session.userId,
+        kind: event.kind,
+        title: event.title,
+        detail: event.detail,
+      })
+      .select("*")
+      .single()
+
+    if (error) {
+      throw new Error(error.message)
+    }
+
+    return toEvent(data)
+  }
+
+  const state = readStateToken(cookieStore.get(MEMBER_STATE_COOKIE)?.value)
+  writeLocalState(response, {
+    ...state,
+    recentEvents: compactLocalEvents([event, ...(state.recentEvents ?? [])]),
+  })
+
+  return event
+}
+
+export async function startAdReward(cookieStore: CookieStore, response: NextResponse, body: unknown) {
+  const auth = await getAuthenticatedMember(cookieStore, response)
+
+  if (!auth) {
+    return null
+  }
+
+  const patchBody = body && typeof body === "object" ? (body as Record<string, unknown>) : {}
+  const placement = normalizeAdRewardPlacement(patchBody.placement)
+  const rewardAmount = rewardAmountForPlacement(placement)
+
+  if (auth.source === "supabase") {
+    if (!auth.session.userId) {
+      throw new Error("Supabase member session is missing a user id.")
+    }
+
+    const serviceSupabase = createSupabaseServiceClient()
+    const { data, error } = await serviceSupabase
+      .from("member_ad_rewards")
+      .insert({
+        user_id: auth.session.userId,
+        placement,
+        reward_amount: rewardAmount,
+        status: "started",
+      })
+      .select("*")
+      .single()
+
+    if (error) {
+      throw new Error(error.message)
+    }
+
+    await serviceSupabase.from("member_events").insert({
+      user_id: auth.session.userId,
+      kind: "ad_reward_start",
+      title: `Ad reward started: ${placement}`,
+      detail: `Reward amount ${rewardAmount}`,
+    })
+
+    return toAdReward(data)
+  }
+
+  const state = readStateToken(cookieStore.get(MEMBER_STATE_COOKIE)?.value)
+  const createdAt = nowIso()
+  const adReward: MemberAdReward = {
+    id: `${createdAt}-${Math.random().toString(16).slice(2)}`,
+    placement,
+    rewardAmount,
+    status: "started",
+    createdAt,
+    creditedAt: null,
+  }
+  const event: MemberEvent = {
+    id: `${createdAt}-ad-start`,
+    kind: "ad_reward_start",
+    title: `Ad reward started: ${placement}`,
+    detail: `Reward amount ${rewardAmount}`,
+    createdAt,
+  }
+
+  writeLocalState(response, {
+    ...state,
+    adRewards: [adReward, ...(state.adRewards ?? [])].slice(0, 8),
+    recentEvents: compactLocalEvents([event, ...(state.recentEvents ?? [])]),
+  })
+
+  return adReward
+}
+
+export async function completeAdReward(cookieStore: CookieStore, response: NextResponse, body: unknown) {
+  const auth = await getAuthenticatedMember(cookieStore, response)
+
+  if (!auth) {
+    return null
+  }
+
+  const patchBody = body && typeof body === "object" ? (body as Record<string, unknown>) : {}
+  const rewardId = typeof patchBody.rewardId === "string" ? patchBody.rewardId : null
+  const placement = normalizeAdRewardPlacement(patchBody.placement)
+
+  if (auth.source === "supabase") {
+    if (!auth.session.userId) {
+      throw new Error("Supabase member session is missing a user id.")
+    }
+
+    const serviceSupabase = createSupabaseServiceClient()
+    const query = serviceSupabase
+      .from("member_ad_rewards")
+      .select("*")
+      .eq("user_id", auth.session.userId)
+      .eq("status", "started")
+      .order("created_at", { ascending: false })
+      .limit(1)
+
+    const { data: adRewardRows, error: readError } = rewardId
+      ? await query.eq("id", rewardId)
+      : await query.eq("placement", placement)
+
+    if (readError) {
+      throw new Error(readError.message)
+    }
+
+    const adReward = Array.isArray(adRewardRows) && adRewardRows[0] ? toAdReward(adRewardRows[0]) : null
+
+    if (!adReward) {
+      throw new Error("No started ad reward was found.")
+    }
+
+    const walletEntry = await applyAuthenticatedWalletEntry(auth, cookieStore, response, {
+      source: "ad_reward",
+      amount: adReward.rewardAmount,
+      referenceId: adReward.id,
+      idempotencyKey: `ad-reward:${adReward.id}`,
+      metadata: { placement: adReward.placement },
+    })
+    const { data: updatedReward, error: updateError } = await serviceSupabase
+      .from("member_ad_rewards")
+      .update({
+        status: "credited",
+        credited_at: walletEntry.createdAt,
+      })
+      .eq("id", adReward.id)
+      .eq("user_id", auth.session.userId)
+      .select("*")
+      .single()
+
+    let creditedRewardRow = updatedReward
+
+    if (updateError) {
+      if (!updateError.message.toLowerCase().includes("permission denied")) {
+        throw new Error(updateError.message)
+      }
+
+      const { data: insertedReward, error: insertError } = await serviceSupabase
+        .from("member_ad_rewards")
+        .insert({
+          user_id: auth.session.userId,
+          placement: adReward.placement,
+          reward_amount: adReward.rewardAmount,
+          status: "credited",
+          credited_at: walletEntry.createdAt,
+        })
+        .select("*")
+        .single()
+
+      if (insertError) {
+        throw new Error(insertError.message)
+      }
+
+      creditedRewardRow = insertedReward
+    }
+
+    await serviceSupabase.from("member_events").insert({
+      user_id: auth.session.userId,
+      kind: "ad_reward_complete",
+      title: `Ad reward credited: ${adReward.placement}`,
+      detail: `Wallet credited ${adReward.rewardAmount}`,
+    })
+
+    return {
+      adReward: toAdReward(creditedRewardRow),
+      walletEntry,
+      wallet: await readAuthenticatedWallet(auth),
+    }
+  }
+
+  const state = readStateToken(cookieStore.get(MEMBER_STATE_COOKIE)?.value)
+  const adRewards = [...(state.adRewards ?? [])]
+  const adRewardIndex = adRewards.findIndex((reward) =>
+    reward.status === "started" && (rewardId ? reward.id === rewardId : reward.placement === placement),
+  )
+
+  if (adRewardIndex < 0) {
+    throw new Error("No started ad reward was found.")
+  }
+
+  const adReward = adRewards[adRewardIndex]
+  const walletEntry = applyLocalWalletEntry(auth, cookieStore, response, {
+    source: "ad_reward",
+    amount: adReward.rewardAmount,
+    referenceId: adReward.id,
+    idempotencyKey: `ad-reward:${adReward.id}`,
+    metadata: { placement: adReward.placement },
+  })
+  const refreshedState = readStateToken(response.cookies.get(MEMBER_STATE_COOKIE)?.value ?? cookieStore.get(MEMBER_STATE_COOKIE)?.value)
+  const creditedReward: MemberAdReward = {
+    ...adReward,
+    status: "credited",
+    creditedAt: walletEntry.createdAt,
+  }
+  adRewards[adRewardIndex] = creditedReward
+  const event: MemberEvent = {
+    id: `${walletEntry.createdAt}-ad-complete`,
+    kind: "ad_reward_complete",
+    title: `Ad reward credited: ${adReward.placement}`,
+    detail: `Wallet credited ${adReward.rewardAmount}`,
+    createdAt: walletEntry.createdAt,
+  }
+
+  writeLocalState(response, {
+    ...refreshedState,
+    adRewards,
+    recentEvents: compactLocalEvents([event, ...(refreshedState.recentEvents ?? [])]),
+  })
+
+  return {
+    adReward: creditedReward,
+    walletEntry,
+    wallet: {
+      ...defaultWallet(),
+      ...refreshedState.wallet,
+      balance: walletEntry.balanceAfter,
+      updatedAt: walletEntry.createdAt,
+      currency: "USD" as const,
+    },
+  }
+}
+
+export async function createPurchase(cookieStore: CookieStore, response: NextResponse, body: unknown) {
+  const auth = await getAuthenticatedMember(cookieStore, response)
+
+  if (!auth) {
+    return null
+  }
+
+  const patchBody = body && typeof body === "object" ? (body as Record<string, unknown>) : {}
+  const product = findMemberProduct(patchBody.productId)
+  const providerReference =
+    typeof patchBody.idempotencyKey === "string" && patchBody.idempotencyKey.trim()
+      ? `stub:${patchBody.idempotencyKey.trim().slice(0, 140)}`
+      : `stub:${Date.now()}-${Math.random().toString(16).slice(2)}`
+
+  if (!product) {
+    throw new Error("A valid product id is required.")
+  }
+
+  if (auth.source === "supabase") {
+    if (!auth.session.userId) {
+      throw new Error("Supabase member session is missing a user id.")
+    }
+
+    const serviceSupabase = createSupabaseServiceClient()
+    const { data, error } = await serviceSupabase
+      .from("member_purchases")
+      .insert({
+        user_id: auth.session.userId,
+        product_id: product.id,
+        amount: product.amount,
+        credits: product.credits,
+        status: "created",
+        provider: "stub",
+        provider_reference: providerReference,
+      })
+      .select("*")
+      .single()
+
+    if (error) {
+      if (error.code === "23505") {
+        const { data: existing, error: existingError } = await serviceSupabase
+          .from("member_purchases")
+          .select("*")
+          .eq("user_id", auth.session.userId)
+          .eq("provider", "stub")
+          .eq("provider_reference", providerReference)
+          .maybeSingle()
+
+        if (existingError) {
+          throw new Error(existingError.message)
+        }
+
+        if (existing) {
+          return toPurchase(existing)
+        }
+      }
+
+      throw new Error(error.message)
+    }
+
+    await serviceSupabase.from("member_events").insert({
+      user_id: auth.session.userId,
+      kind: "purchase_attempt",
+      title: `Purchase created: ${product.id}`,
+      detail: `Stub purchase for ${product.credits} credits`,
+    })
+
+    return toPurchase(data)
+  }
+
+  const state = readStateToken(cookieStore.get(MEMBER_STATE_COOKIE)?.value)
+  const existing = (state.purchases ?? []).find((purchase) => purchase.providerReference === providerReference)
+
+  if (existing) {
+    return existing
+  }
+
+  const createdAt = nowIso()
+  const purchase: MemberPurchase = {
+    id: `${createdAt}-${Math.random().toString(16).slice(2)}`,
+    productId: product.id,
+    amount: product.amount,
+    credits: product.credits,
+    status: "created",
+    provider: "stub",
+    providerReference,
+    createdAt,
+    creditedAt: null,
+  }
+  const event: MemberEvent = {
+    id: `${createdAt}-purchase-attempt`,
+    kind: "purchase_attempt",
+    title: `Purchase created: ${product.id}`,
+    detail: `Stub purchase for ${product.credits} credits`,
+    createdAt,
+  }
+
+  writeLocalState(response, {
+    ...state,
+    purchases: [purchase, ...(state.purchases ?? [])].slice(0, 8),
+    recentEvents: compactLocalEvents([event, ...(state.recentEvents ?? [])]),
+  })
+
+  return purchase
+}
+
+export async function completePurchase(cookieStore: CookieStore, response: NextResponse, purchaseId: string) {
+  const auth = await getAuthenticatedMember(cookieStore, response)
+
+  if (!auth) {
+    return null
+  }
+
+  if (auth.source === "supabase") {
+    if (!auth.session.userId) {
+      throw new Error("Supabase member session is missing a user id.")
+    }
+
+    const serviceSupabase = createSupabaseServiceClient()
+    const { data: purchaseRow, error: readError } = await serviceSupabase
+      .from("member_purchases")
+      .select("*")
+      .eq("id", purchaseId)
+      .eq("user_id", auth.session.userId)
+      .maybeSingle()
+
+    if (readError) {
+      throw new Error(readError.message)
+    }
+
+    if (!purchaseRow) {
+      throw new Error("Purchase was not found.")
+    }
+
+    const purchase = toPurchase(purchaseRow)
+
+    if (purchase.status === "credited") {
+      return {
+        purchase,
+        walletEntry: null,
+        wallet: await readAuthenticatedWallet(auth),
+      }
+    }
+
+    const walletEntry = await applyAuthenticatedWalletEntry(auth, cookieStore, response, {
+      source: "purchase",
+      amount: purchase.credits,
+      referenceId: purchase.id,
+      idempotencyKey: `purchase:${purchase.id}`,
+      metadata: { productId: purchase.productId, provider: purchase.provider },
+    })
+    const { data: updatedPurchase, error: updateError } = await serviceSupabase
+      .from("member_purchases")
+      .update({
+        status: "credited",
+        credited_at: walletEntry.createdAt,
+      })
+      .eq("id", purchase.id)
+      .eq("user_id", auth.session.userId)
+      .select("*")
+      .single()
+
+    let creditedPurchaseRow = updatedPurchase
+
+    if (updateError) {
+      if (!updateError.message.toLowerCase().includes("permission denied")) {
+        throw new Error(updateError.message)
+      }
+
+      const fallbackReference = `${purchase.providerReference ?? purchase.id}:credited`
+      const { data: insertedPurchase, error: insertError } = await serviceSupabase
+        .from("member_purchases")
+        .insert({
+          user_id: auth.session.userId,
+          product_id: purchase.productId,
+          amount: purchase.amount,
+          credits: purchase.credits,
+          status: "credited",
+          provider: purchase.provider,
+          provider_reference: fallbackReference,
+          credited_at: walletEntry.createdAt,
+        })
+        .select("*")
+        .single()
+
+      if (insertError) {
+        if (insertError.code === "23505") {
+          const { data: existingPurchase, error: existingError } = await serviceSupabase
+            .from("member_purchases")
+            .select("*")
+            .eq("user_id", auth.session.userId)
+            .eq("provider", purchase.provider)
+            .eq("provider_reference", fallbackReference)
+            .maybeSingle()
+
+          if (existingError) {
+            throw new Error(existingError.message)
+          }
+
+          if (!existingPurchase) {
+            throw new Error(insertError.message)
+          }
+
+          creditedPurchaseRow = existingPurchase
+        } else {
+          throw new Error(insertError.message)
+        }
+      } else {
+        creditedPurchaseRow = insertedPurchase
+      }
+    }
+
+    await serviceSupabase.from("member_events").insert({
+      user_id: auth.session.userId,
+      kind: "purchase_success",
+      title: `Purchase credited: ${purchase.productId}`,
+      detail: `Wallet credited ${purchase.credits}`,
+    })
+
+    return {
+      purchase: toPurchase(creditedPurchaseRow),
+      walletEntry,
+      wallet: await readAuthenticatedWallet(auth),
+    }
+  }
+
+  const state = readStateToken(cookieStore.get(MEMBER_STATE_COOKIE)?.value)
+  const purchases = [...(state.purchases ?? [])]
+  const purchaseIndex = purchases.findIndex((purchase) => purchase.id === purchaseId)
+
+  if (purchaseIndex < 0) {
+    throw new Error("Purchase was not found.")
+  }
+
+  const purchase = purchases[purchaseIndex]
+
+  if (purchase.status === "credited") {
+    return {
+      purchase,
+      walletEntry: null,
+      wallet: {
+        ...defaultWallet(),
+        ...state.wallet,
+        currency: "USD" as const,
+      },
+    }
+  }
+
+  const walletEntry = applyLocalWalletEntry(auth, cookieStore, response, {
+    source: "purchase",
+    amount: purchase.credits,
+    referenceId: purchase.id,
+    idempotencyKey: `purchase:${purchase.id}`,
+    metadata: { productId: purchase.productId, provider: purchase.provider },
+  })
+  const refreshedState = readStateToken(response.cookies.get(MEMBER_STATE_COOKIE)?.value ?? cookieStore.get(MEMBER_STATE_COOKIE)?.value)
+  const creditedPurchase: MemberPurchase = {
+    ...purchase,
+    status: "credited",
+    creditedAt: walletEntry.createdAt,
+  }
+  purchases[purchaseIndex] = creditedPurchase
+  const event: MemberEvent = {
+    id: `${walletEntry.createdAt}-purchase-success`,
+    kind: "purchase_success",
+    title: `Purchase credited: ${purchase.productId}`,
+    detail: `Wallet credited ${purchase.credits}`,
+    createdAt: walletEntry.createdAt,
+  }
+
+  writeLocalState(response, {
+    ...refreshedState,
+    purchases,
+    recentEvents: compactLocalEvents([event, ...(refreshedState.recentEvents ?? [])]),
+  })
+
+  return {
+    purchase: creditedPurchase,
+    walletEntry,
+    wallet: {
+      ...defaultWallet(),
+      ...refreshedState.wallet,
+      balance: walletEntry.balanceAfter,
+      updatedAt: walletEntry.createdAt,
+      currency: "USD" as const,
+    },
+  }
+}
+
 export async function recordGameProgress(cookieStore: CookieStore, response: NextResponse, body: unknown) {
   const auth = await getAuthenticatedMember(cookieStore, response)
 
@@ -1517,6 +2372,10 @@ export async function recordGameProgress(cookieStore: CookieStore, response: Nex
 
   if (!gameSlug || !outcome) {
     throw new Error("A game slug and valid outcome are required.")
+  }
+
+  if (!getPlayableTable(gameSlug)) {
+    throw new Error("Game slug is not playable.")
   }
 
   const delta = Math.min(1000000, Math.max(-1000000, normalizeMoney(patchBody.delta)))

--- a/lib/member-round-client.ts
+++ b/lib/member-round-client.ts
@@ -1,0 +1,32 @@
+export type ClientRoundOutcome = "win" | "loss" | "push"
+
+export interface ClientGameRoundInput {
+  gameSlug: string
+  outcome: ClientRoundOutcome
+  delta: number
+  bankroll: number
+  summary: string
+  idempotencyKey: string
+  tableSessionId?: string
+  totalStake: number
+  betSnapshot: Record<string, unknown>
+  resultSnapshot: Record<string, unknown>
+}
+
+export async function recordClientGameRound(input: ClientGameRoundInput) {
+  const response = await fetch("/api/member/game-rounds", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(input),
+  })
+  const payload = (await response.json().catch(() => null)) as {
+    error?: string
+    progress?: { bankroll?: unknown }
+  } | null
+
+  if (!response.ok) {
+    throw new Error(payload?.error ?? "Unable to record game round.")
+  }
+
+  return typeof payload?.progress?.bankroll === "number" ? payload.progress.bankroll : null
+}

--- a/lib/table-session-client.ts
+++ b/lib/table-session-client.ts
@@ -50,7 +50,11 @@ export async function openClientTableSession(
   return parsed
 }
 
-export async function cashOutClientTableSession(sessionId: string, idempotencyPrefix: string) {
+export async function cashOutClientTableSession(
+  sessionId: string,
+  idempotencyPrefix: string,
+  expectedChipBalance?: number,
+) {
   const response = await fetch(`/api/member/table-sessions/${sessionId}/cash-out`, {
     method: "POST",
     headers: {
@@ -58,6 +62,7 @@ export async function cashOutClientTableSession(sessionId: string, idempotencyPr
     },
     body: JSON.stringify({
       idempotencyKey: `${idempotencyPrefix}-${sessionId}-${Date.now()}`,
+      expectedChipBalance,
     }),
   })
   const payload = (await response.json().catch(() => null)) as TableSessionMutationPayload | null

--- a/supabase/migrations/20260510032015_member_mvp_event_ad_purchase_routes.sql
+++ b/supabase/migrations/20260510032015_member_mvp_event_ad_purchase_routes.sql
@@ -1,0 +1,8 @@
+grant update on table public.member_ad_rewards to service_role;
+grant update on table public.member_purchases to service_role;
+
+create index if not exists member_ad_rewards_user_status_created_at_idx
+on public.member_ad_rewards (user_id, status, created_at desc);
+
+create index if not exists member_purchases_user_status_created_at_idx
+on public.member_purchases (user_id, status, created_at desc);


### PR DESCRIPTION
## 中文

### 变更
- 统一四个游戏的回合记录入口到 `/api/member/game-rounds`。
- 修复桌台买入、每局结算、离桌 cash-out 的钱包闭环。
- cash-out 提交当前桌台筹码并在后端校准，避免旧筹码被退回钱包。
- 首页和游戏页改为动态读取，首页会刷新会员数据并按钱包游戏流水计算今日净赢。
- 增加会员 events、ad rewards、products、purchases API 骨架。
- 为 Supabase ad rewards / purchases 增加 service_role update grant 和索引 migration。
- RPC 缺失时保留 service-role fallback；当前 Supabase 后端已手动部署 `settle_member_table_session_round`。

### 验证
- `corepack pnpm typecheck`
- `corepack pnpm build`
- `git diff --check`
- 手动浏览器回归：Baccarat / Blackjack / Roulette / Dice 的买入、输赢、离桌结算。
- 后端核对：wallet ledger、game rounds、table sessions、game progress 闭环一致。

## English

### Changes
- Unified all four games on `/api/member/game-rounds` for round recording.
- Fixed the wallet loop across table buy-in, round settlement, and cash-out.
- Cash-out now submits the current table-chip balance and reconciles it server-side to prevent stale chip refunds.
- Lobby and game routes now read dynamically; lobby refreshes member data and computes today net from gaming wallet ledger entries.
- Added member events, ad rewards, products, and purchases API scaffolding.
- Added Supabase service-role update grants and indexes for ad rewards and purchases.
- Kept a service-role fallback for missing RPCs; `settle_member_table_session_round` has been manually deployed to the Supabase backend.

### Verification
- `corepack pnpm typecheck`
- `corepack pnpm build`
- `git diff --check`
- Manual browser regression for Baccarat / Blackjack / Roulette / Dice buy-in, win/loss, and cash-out flows.
- Backend verification confirmed wallet ledger, game rounds, table sessions, and game progress are consistent.
