### PR TITLE
GHO-21/GHO-26: Registration flow and Turnstile protection

### DIFF
--- a/app/api/auth/oauth/route.ts
+++ b/app/api/auth/oauth/route.ts
@@ -9,27 +9,27 @@ const providerMap = {
   apple: "apple",
   microsoft: "azure",
   facebook: "facebook",
+  amazon: "custom:amazon",
   x: "x",
 } satisfies Record<string, Provider>
 
 function resolveRedirectTarget(nextTarget: unknown) {
-  return typeof nextTarget === "string" && nextTarget.startsWith("/") ? nextTarget : "/"
-}
-
-export async function POST(request: Request) {
-  if (!isSupabaseAuthConfigured()) {
-    return NextResponse.json({ error: "Supabase authentication is not configured." }, { status: 501 })
+  if (typeof nextTarget !== "string" || !nextTarget.startsWith("/") || nextTarget.startsWith("//")) {
+    return "/"
   }
 
-  const body = (await request.json().catch(() => null)) as {
-    provider?: unknown
-    next?: unknown
-  } | null
-  const providerKey = typeof body?.provider === "string" ? body.provider : ""
+  return nextTarget
+}
+
+async function createOAuthRedirect(request: Request, providerKey: string, nextTarget: unknown) {
+  if (!isSupabaseAuthConfigured()) {
+    return { error: "Supabase authentication is not configured.", status: 501 }
+  }
+
   const provider = providerMap[providerKey as keyof typeof providerMap]
 
   if (!provider) {
-    return NextResponse.json({ error: "Unsupported sign-in provider." }, { status: 400 })
+    return { error: "Unsupported sign-in provider.", status: 400 }
   }
 
   const response = NextResponse.json(
@@ -43,7 +43,7 @@ export async function POST(request: Request) {
   const cookieStore = await cookies()
   const supabase = createSupabaseAuthClient(cookieStore, response)
   const origin = new URL(request.url).origin
-  const next = encodeURIComponent(resolveRedirectTarget(body?.next))
+  const next = encodeURIComponent(resolveRedirectTarget(nextTarget))
   const { data, error } = await supabase.auth.signInWithOAuth({
     provider,
     options: {
@@ -52,13 +52,50 @@ export async function POST(request: Request) {
   })
 
   if (error || !data.url) {
-    return NextResponse.json({ error: error?.message ?? "Unable to start sign in." }, { status: 502 })
+    return { error: error?.message ?? "Unable to start sign in.", status: 502 }
+  }
+
+  return { redirectTo: data.url, headers: response.headers }
+}
+
+export async function GET(request: Request) {
+  const requestUrl = new URL(request.url)
+  const result = await createOAuthRedirect(
+    request,
+    requestUrl.searchParams.get("provider") ?? "",
+    requestUrl.searchParams.get("next"),
+  )
+
+  if ("error" in result) {
+    const next = encodeURIComponent(resolveRedirectTarget(requestUrl.searchParams.get("next")))
+    return NextResponse.redirect(new URL(`/login?next=${next}&authError=oauth`, requestUrl.origin), {
+      headers: {
+        "cache-control": "private, no-store",
+      },
+    })
+  }
+
+  return NextResponse.redirect(result.redirectTo, {
+    headers: result.headers,
+  })
+}
+
+export async function POST(request: Request) {
+  const body = (await request.json().catch(() => null)) as {
+    provider?: unknown
+    next?: unknown
+  } | null
+  const providerKey = typeof body?.provider === "string" ? body.provider : ""
+  const result = await createOAuthRedirect(request, providerKey, body?.next)
+
+  if ("error" in result) {
+    return NextResponse.json({ error: result.error }, { status: result.status })
   }
 
   return NextResponse.json(
-    { redirectTo: data.url },
+    { redirectTo: result.redirectTo },
     {
-      headers: response.headers,
+      headers: result.headers,
     },
   )
 }

--- a/app/api/auth/register/route.ts
+++ b/app/api/auth/register/route.ts
@@ -1,0 +1,131 @@
+import { cookies } from "next/headers"
+import { NextResponse } from "next/server"
+
+import {
+  createSessionFromSupabaseUser,
+  createSupabaseAuthClient,
+  isSupabaseAuthConfigured,
+} from "@/lib/server-auth"
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+const MIN_PASSWORD_LENGTH = 8
+const MAX_DISPLAY_NAME_LENGTH = 60
+
+function resolveRedirectTarget(nextTarget: unknown) {
+  if (typeof nextTarget !== "string" || !nextTarget.startsWith("/") || nextTarget.startsWith("//")) {
+    return "/"
+  }
+
+  return nextTarget
+}
+
+function parseRegistrationBody(body: {
+  email?: unknown
+  password?: unknown
+  displayName?: unknown
+  captchaToken?: unknown
+  next?: unknown
+} | null) {
+  const email = typeof body?.email === "string" ? body.email.trim().toLowerCase() : ""
+  const password = typeof body?.password === "string" ? body.password : ""
+  const displayName = typeof body?.displayName === "string" ? body.displayName.trim() : ""
+  const captchaToken = typeof body?.captchaToken === "string" ? body.captchaToken.trim() : ""
+  const next = resolveRedirectTarget(body?.next)
+
+  if (!EMAIL_PATTERN.test(email)) {
+    return { error: "A valid email address is required." }
+  }
+
+  if (password.length < MIN_PASSWORD_LENGTH) {
+    return { error: "Password must be at least 8 characters." }
+  }
+
+  if (!displayName) {
+    return { error: "Player name is required." }
+  }
+
+  if (displayName.length > MAX_DISPLAY_NAME_LENGTH) {
+    return { error: "Player name must be 60 characters or fewer." }
+  }
+
+  if (!captchaToken) {
+    return { error: "Please complete the security check." }
+  }
+
+  return { data: { email, password, displayName, captchaToken, next } }
+}
+
+export async function POST(request: Request) {
+  if (!isSupabaseAuthConfigured()) {
+    return NextResponse.json({ error: "Supabase authentication is not configured." }, { status: 501 })
+  }
+
+  const body = (await request.json().catch(() => null)) as {
+    email?: unknown
+    password?: unknown
+    displayName?: unknown
+    captchaToken?: unknown
+    next?: unknown
+  } | null
+  const parsed = parseRegistrationBody(body)
+
+  if ("error" in parsed) {
+    return NextResponse.json({ error: parsed.error }, { status: 400 })
+  }
+
+  const response = NextResponse.json(
+    { session: null },
+    {
+      headers: {
+        "cache-control": "private, no-store",
+      },
+    },
+  )
+  const cookieStore = await cookies()
+  const supabase = createSupabaseAuthClient(cookieStore, response)
+  const origin = new URL(request.url).origin
+  const { email, password, displayName, captchaToken, next } = parsed.data
+  const { data, error } = await supabase.auth.signUp({
+    email,
+    password,
+    options: {
+      captchaToken,
+      data: {
+        display_name: displayName,
+      },
+      emailRedirectTo: `${origin}/auth/callback?next=${encodeURIComponent(next)}`,
+    },
+  })
+
+  if (error) {
+    const message = /already registered/i.test(error.message)
+      ? "An account with this email already exists."
+      : error.message || "Unable to create account."
+
+    return NextResponse.json({ error: message }, { status: 400 })
+  }
+
+  if (data.session && data.user) {
+    return NextResponse.json(
+      {
+        confirmationRequired: false,
+        session: createSessionFromSupabaseUser(data.user),
+      },
+      {
+        headers: response.headers,
+        status: 201,
+      },
+    )
+  }
+
+  return NextResponse.json(
+    {
+      confirmationRequired: true,
+      session: null,
+    },
+    {
+      headers: response.headers,
+      status: 202,
+    },
+  )
+}

--- a/app/login/login-form.tsx
+++ b/app/login/login-form.tsx
@@ -2,12 +2,13 @@
 
 import Link from "next/link"
 import Image from "next/image"
-import { useEffect, useState } from "react"
+import Script from "next/script"
+import { useEffect, useRef, useState } from "react"
 import { useRouter } from "next/navigation"
-import { ArrowRight, Eye, EyeOff, Lock, Mail, Spade } from "lucide-react"
+import { ArrowRight, Eye, EyeOff, Lock, Mail, Spade, UserPlus } from "lucide-react"
 
 import { Button } from "@/components/ui/button"
-import { loginMember, readMemberSession, startOAuthSignIn, type OAuthProviderKey } from "@/lib/member-session"
+import { loginMember, readMemberSession, registerMember, startOAuthSignIn, type OAuthProviderKey } from "@/lib/member-session"
 import { cn } from "@/lib/utils"
 
 const providerButtons = [
@@ -50,9 +51,9 @@ const providerButtons = [
   {
     key: "amazon",
     label: "Amazon",
-    className: "bg-[#f8a51c] hover:bg-[#eb9b18]",
+    className: "bg-[#f8d994] hover:bg-[#edcb7c]",
     src: "/brands/amazon-logo.png",
-    imgClassName: "h-5 w-auto max-w-[5.7rem]",
+    imgClassName: "max-h-5 w-auto max-w-[5.7rem]",
     width: 91,
     height: 20,
   },
@@ -66,7 +67,7 @@ const providerButtons = [
     height: 20,
   },
 ] satisfies Array<{
-  key: OAuthProviderKey | "amazon"
+  key: OAuthProviderKey
   label: string
   className: string
   src: string
@@ -81,11 +82,38 @@ const stats = [
   { value: "99.9%", label: "Uptime" },
 ]
 
+const turnstileSiteKey = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY ?? ""
+
+declare global {
+  interface Window {
+    turnstile?: {
+      render: (
+        container: HTMLElement,
+        options: {
+          sitekey: string
+          appearance?: "always" | "execute" | "interaction-only"
+          theme?: "auto" | "light" | "dark"
+          size?: "normal" | "compact" | "flexible" | "invisible"
+          callback: (token: string) => void
+          "expired-callback": () => void
+          "error-callback": () => void
+        },
+      ) => string
+      getResponse?: (widgetId?: string) => string
+      reset: (widgetId?: string) => void
+      remove?: (widgetId: string) => void
+    }
+  }
+}
+
 interface TestAccountHint {
   account: string
   password: string
   displayName?: string
 }
+
+type AuthMode = "sign-in" | "register"
+type CaptchaStatus = "idle" | "loading" | "verified" | "expired" | "error"
 
 function resolveRedirectTarget(nextTarget: string | null) {
   if (!nextTarget || !nextTarget.startsWith("/")) {
@@ -138,7 +166,7 @@ function ProviderButton({
           width={width}
           height={height}
           className={imgClassName}
-          style={keepImageWidthAuto ? { width: "auto" } : undefined}
+          style={keepImageWidthAuto ? { height: "auto", width: "auto" } : undefined}
         />
       )}
     </button>
@@ -155,6 +183,7 @@ function Field({
   icon,
   trailing,
   action,
+  autoComplete,
 }: {
   id: string
   label: string
@@ -165,6 +194,7 @@ function Field({
   icon: React.ReactNode
   trailing?: React.ReactNode
   action?: React.ReactNode
+  autoComplete?: string
 }) {
   return (
     <label htmlFor={id} className="block">
@@ -180,6 +210,7 @@ function Field({
           value={value}
           onChange={(event) => onChange(event.target.value)}
           placeholder={placeholder}
+          autoComplete={autoComplete}
           className="h-full w-full bg-transparent text-base text-foreground outline-none placeholder:text-[var(--auth-faint-text)]"
         />
         {trailing ? <span className="ml-3 text-[var(--auth-faint-text)]">{trailing}</span> : null}
@@ -189,19 +220,61 @@ function Field({
 }
 
 export function LoginForm({
+  initialMode = "sign-in",
   next,
   testAccount,
 }: {
+  initialMode?: AuthMode
   next?: string
   testAccount?: TestAccountHint | null
 }) {
   const router = useRouter()
+  const [authMode, setAuthMode] = useState<AuthMode>(initialMode)
   const [email, setEmail] = useState("")
+  const [displayName, setDisplayName] = useState("")
   const [password, setPassword] = useState("")
+  const [confirmPassword, setConfirmPassword] = useState("")
   const [showPassword, setShowPassword] = useState(false)
   const [loadingProvider, setLoadingProvider] = useState<string | null>(null)
   const [errorMessage, setErrorMessage] = useState("")
+  const [statusMessage, setStatusMessage] = useState("")
   const [isSubmitting, setIsSubmitting] = useState(false)
+  const [captchaToken, setCaptchaToken] = useState("")
+  const [captchaStatus, setCaptchaStatus] = useState<CaptchaStatus>("idle")
+  const [turnstileReady, setTurnstileReady] = useState(false)
+  const turnstileContainerRef = useRef<HTMLDivElement | null>(null)
+  const turnstileWidgetIdRef = useRef<string | null>(null)
+  const isRegisterMode = authMode === "register"
+
+  function resetCaptcha() {
+    setCaptchaToken("")
+    setCaptchaStatus(isRegisterMode && turnstileSiteKey ? "loading" : "idle")
+
+    if (turnstileWidgetIdRef.current && window.turnstile) {
+      window.turnstile.reset(turnstileWidgetIdRef.current)
+      return
+    }
+
+    if (isRegisterMode && typeof window !== "undefined") {
+      window.location.reload()
+    }
+  }
+
+  function readCaptchaTokenFromWidget() {
+    const widgetResponse = turnstileWidgetIdRef.current
+      ? (window.turnstile?.getResponse?.(turnstileWidgetIdRef.current)?.trim() ?? "")
+      : ""
+
+    if (widgetResponse) {
+      return widgetResponse
+    }
+
+    const hiddenInput = turnstileContainerRef.current?.querySelector<HTMLInputElement>(
+      'input[name="cf-turnstile-response"]',
+    )
+
+    return hiddenInput?.value.trim() ?? ""
+  }
 
   useEffect(() => {
     let cancelled = false
@@ -217,6 +290,90 @@ export function LoginForm({
     }
   }, [next, router])
 
+  useEffect(() => {
+    if (!isRegisterMode) {
+      setCaptchaToken("")
+      setCaptchaStatus("idle")
+      return
+    }
+
+    if (!turnstileReady || !turnstileSiteKey || !turnstileContainerRef.current || !window.turnstile) {
+      setCaptchaStatus(turnstileSiteKey ? "loading" : "idle")
+      return
+    }
+
+    setCaptchaStatus("loading")
+    turnstileWidgetIdRef.current = window.turnstile.render(turnstileContainerRef.current, {
+      sitekey: turnstileSiteKey,
+      appearance: "always",
+      theme: "light",
+      size: "normal",
+      callback(token) {
+        setCaptchaToken(token)
+        setCaptchaStatus("verified")
+      },
+      "expired-callback"() {
+        setCaptchaToken("")
+        setCaptchaStatus("expired")
+      },
+      "error-callback"() {
+        setCaptchaToken("")
+        setCaptchaStatus("error")
+      },
+    })
+
+    return () => {
+      if (turnstileWidgetIdRef.current && window.turnstile?.remove) {
+        window.turnstile.remove(turnstileWidgetIdRef.current)
+      }
+      turnstileWidgetIdRef.current = null
+    }
+  }, [isRegisterMode, turnstileReady])
+
+  useEffect(() => {
+    if (!isRegisterMode || !turnstileSiteKey || captchaToken) {
+      return
+    }
+
+    const startedAt = Date.now()
+    const tokenCheck = window.setInterval(() => {
+      const activeCaptchaToken = readCaptchaTokenFromWidget()
+
+      if (activeCaptchaToken) {
+        setCaptchaToken(activeCaptchaToken)
+        setCaptchaStatus("verified")
+        window.clearInterval(tokenCheck)
+        return
+      }
+
+      if (Date.now() - startedAt > 9000) {
+        setCaptchaStatus("error")
+        window.clearInterval(tokenCheck)
+      }
+    }, 500)
+
+    return () => {
+      window.clearInterval(tokenCheck)
+    }
+  }, [captchaToken, isRegisterMode, turnstileReady])
+
+  function switchAuthMode(mode: AuthMode) {
+    setAuthMode(mode)
+    setErrorMessage("")
+    setStatusMessage("")
+
+    const params = new URLSearchParams()
+    if (mode === "register") {
+      params.set("mode", "register")
+    }
+    if (next) {
+      params.set("next", next)
+    }
+
+    const query = params.toString()
+    router.replace(query ? `/login?${query}` : "/login", { scroll: false })
+  }
+
   async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault()
 
@@ -226,12 +383,87 @@ export function LoginForm({
       return
     }
 
+    if (isRegisterMode) {
+      const trimmedDisplayName = displayName.trim()
+      if (!trimmedDisplayName) {
+        setErrorMessage("Please enter a player name.")
+        return
+      }
+
+      if (password.trim().length < 8) {
+        setErrorMessage("Password must be at least 8 characters for account creation.")
+        return
+      }
+
+      if (password !== confirmPassword) {
+        setErrorMessage("Passwords do not match.")
+        return
+      }
+
+      if (!turnstileSiteKey) {
+        setErrorMessage("Security check is not configured.")
+        return
+      }
+
+      const activeCaptchaToken = captchaToken || readCaptchaTokenFromWidget()
+
+      if (!activeCaptchaToken) {
+        setErrorMessage("Please complete the security check.")
+        return
+      }
+
+      if (!captchaToken) {
+        setCaptchaToken(activeCaptchaToken)
+        setCaptchaStatus("verified")
+      }
+
+      setErrorMessage("")
+      setStatusMessage("")
+      setIsSubmitting(true)
+
+      try {
+        const result = await registerMember({
+          email: trimmedEmail,
+          password,
+          displayName: trimmedDisplayName,
+          captchaToken: activeCaptchaToken,
+          next,
+        })
+
+        if (result.session) {
+          router.push(resolveRedirectTarget(next ?? null))
+          router.refresh()
+          return
+        }
+
+        if (result.confirmationRequired) {
+          setStatusMessage("Check your email to confirm your Taihu member account before signing in.")
+          setPassword("")
+          setConfirmPassword("")
+          return
+        }
+
+        setPassword("")
+        setConfirmPassword("")
+        switchAuthMode("sign-in")
+        setStatusMessage("Account created. You can sign in now.")
+      } catch (error) {
+        setErrorMessage(error instanceof Error ? error.message : "Unable to create account.")
+        resetCaptcha()
+      } finally {
+        setIsSubmitting(false)
+      }
+      return
+    }
+
     if (password.trim().length < 4) {
       setErrorMessage("Password must be at least 4 characters for demo sign in.")
       return
     }
 
     setErrorMessage("")
+    setStatusMessage("")
+    resetCaptcha()
     setIsSubmitting(true)
 
     try {
@@ -252,17 +484,15 @@ export function LoginForm({
 
     setEmail(testAccount.account)
     setPassword(testAccount.password)
+    setAuthMode("sign-in")
     setErrorMessage("")
+    setStatusMessage("")
   }
 
-  async function handleProviderClick(provider: OAuthProviderKey | "amazon") {
-    if (provider === "amazon") {
-      setErrorMessage("Amazon sign-in is not supported by Supabase Auth yet.")
-      return
-    }
-
+  async function handleProviderClick(provider: OAuthProviderKey) {
     setLoadingProvider(provider)
     setErrorMessage("")
+    setStatusMessage("")
 
     try {
       await startOAuthSignIn(provider, next)
@@ -274,6 +504,16 @@ export function LoginForm({
 
   return (
     <main className="casino-auth-shell relative min-h-screen overflow-hidden">
+      {isRegisterMode && turnstileSiteKey ? (
+        <Script
+          src="https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit"
+          strategy="afterInteractive"
+          onLoad={() => setTurnstileReady(true)}
+          onReady={() => setTurnstileReady(true)}
+          onError={() => setCaptchaStatus("error")}
+        />
+      ) : null}
+
       <div className="pointer-events-none absolute inset-0">
         <div className="lobby-ambient-orb absolute left-0 top-0 h-80 w-80 rounded-full blur-3xl" />
         <div className="lobby-ambient-orb lobby-ambient-orb-secondary absolute bottom-0 right-0 h-96 w-96 rounded-full blur-3xl" />
@@ -347,11 +587,38 @@ export function LoginForm({
             </div>
 
             <div className="text-center">
-              <h2 className="font-serif text-[2.55rem] font-semibold tracking-tight text-foreground">Welcome Back</h2>
-              <p className="mt-2.5 text-base text-[var(--auth-soft-text)]">Sign in to continue your gaming journey</p>
+              <h2 className="font-serif text-[2.55rem] font-semibold tracking-tight text-foreground">
+                {isRegisterMode ? "Create Account" : "Welcome Back"}
+              </h2>
+              <p className="mt-2.5 text-base text-[var(--auth-soft-text)]">
+                {isRegisterMode ? "Create your Taihu member profile" : "Sign in to continue your gaming journey"}
+              </p>
             </div>
 
-            {testAccount ? (
+            <div className="mt-6 grid grid-cols-2 rounded-[1.25rem] border border-primary/15 bg-background/45 p-1">
+              <button
+                type="button"
+                onClick={() => switchAuthMode("sign-in")}
+                className={cn(
+                  "h-11 rounded-[1rem] text-sm font-semibold transition",
+                  !isRegisterMode ? "bg-primary text-primary-foreground shadow-sm" : "text-[var(--auth-soft-text)] hover:text-foreground",
+                )}
+              >
+                Sign in
+              </button>
+              <button
+                type="button"
+                onClick={() => switchAuthMode("register")}
+                className={cn(
+                  "h-11 rounded-[1rem] text-sm font-semibold transition",
+                  isRegisterMode ? "bg-primary text-primary-foreground shadow-sm" : "text-[var(--auth-soft-text)] hover:text-foreground",
+                )}
+              >
+                Create account
+              </button>
+            </div>
+
+            {testAccount && !isRegisterMode ? (
               <div className="mt-6 rounded-[1.35rem] border border-primary/20 bg-primary/10 p-4 text-left">
                 <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                   <div>
@@ -379,19 +646,35 @@ export function LoginForm({
                   height={provider.height}
                   loading={loadingProvider === provider.key}
                   onClick={() => handleProviderClick(provider.key)}
-                  disabled={provider.key === "amazon"}
                   keepImageWidthAuto={provider.key === "amazon"}
                 />
               ))}
             </div>
 
+            <p className="mt-4 text-center text-sm leading-6 text-[var(--auth-soft-text)]">
+              First-time social sign-in automatically creates a Taihu member profile.
+            </p>
+
             <div className="my-7 flex items-center gap-4 text-sm text-[var(--auth-faint-text)]">
               <div className="h-px flex-1 bg-[var(--auth-divider)]" />
-              <span className="text-base">or continue with email</span>
+              <span className="text-base">{isRegisterMode ? "or create with email" : "or continue with email"}</span>
               <div className="h-px flex-1 bg-[var(--auth-divider)]" />
             </div>
 
             <form onSubmit={handleSubmit} className="space-y-4">
+              {isRegisterMode ? (
+                <Field
+                  id="displayName"
+                  label="Player Name"
+                  type="text"
+                  value={displayName}
+                  onChange={setDisplayName}
+                  placeholder="Choose your member name"
+                  autoComplete="name"
+                  icon={<UserPlus className="h-5 w-5" />}
+                />
+              ) : null}
+
               <Field
                 id="email"
                 label="Email Address"
@@ -399,6 +682,7 @@ export function LoginForm({
                 value={email}
                 onChange={setEmail}
                 placeholder="Enter your email"
+                autoComplete="email"
                 icon={<Mail className="h-5 w-5" />}
               />
 
@@ -409,11 +693,14 @@ export function LoginForm({
                 value={password}
                 onChange={setPassword}
                 placeholder="Enter your password"
+                autoComplete={isRegisterMode ? "new-password" : "current-password"}
                 icon={<Lock className="h-5 w-5" />}
                 action={
+                  !isRegisterMode ? (
                   <Link href="#" className="text-sm font-medium text-primary hover:text-primary/80">
                     Forgot password?
                   </Link>
+                  ) : null
                 }
                 trailing={
                   <button
@@ -427,9 +714,60 @@ export function LoginForm({
                 }
               />
 
+              {isRegisterMode ? (
+                <Field
+                  id="confirmPassword"
+                  label="Confirm Password"
+                  type={showPassword ? "text" : "password"}
+                  value={confirmPassword}
+                  onChange={setConfirmPassword}
+                  placeholder="Confirm your password"
+                  autoComplete="new-password"
+                  icon={<Lock className="h-5 w-5" />}
+                />
+              ) : null}
+
+              {isRegisterMode ? (
+                <div className="rounded-[1.2rem] border border-primary/15 bg-background/50 px-4 py-3">
+                  {turnstileSiteKey ? (
+                    <div className="space-y-2">
+                      <div ref={turnstileContainerRef} className="min-h-[65px]" />
+                      {captchaStatus === "loading" ? (
+                        <p className="text-xs font-medium text-[var(--auth-soft-text)]">Loading security check...</p>
+                      ) : null}
+                      {captchaStatus === "verified" ? (
+                        <p className="text-xs font-semibold text-primary">Security check complete.</p>
+                      ) : null}
+                      {captchaStatus === "expired" || captchaStatus === "error" ? (
+                        <div className="flex items-center justify-between gap-3">
+                          <p className="text-xs font-medium text-red-700 dark:text-red-200">
+                            {captchaStatus === "expired" ? "Security check expired." : "Security check failed."}
+                          </p>
+                          <button
+                            type="button"
+                            onClick={resetCaptcha}
+                            className="text-xs font-semibold text-primary hover:text-primary/80"
+                          >
+                            Retry
+                          </button>
+                        </div>
+                      ) : null}
+                    </div>
+                  ) : (
+                    <p className="text-sm text-red-700 dark:text-red-200">Security check is not configured.</p>
+                  )}
+                </div>
+              ) : null}
+
               {errorMessage ? (
                 <div className="rounded-[1.2rem] border border-red-500/25 bg-red-500/10 px-4 py-3 text-sm text-red-700 dark:text-red-200">
                   {errorMessage}
+                </div>
+              ) : null}
+
+              {statusMessage ? (
+                <div className="rounded-[1.2rem] border border-primary/25 bg-primary/10 px-4 py-3 text-sm leading-6 text-foreground">
+                  {statusMessage}
                 </div>
               ) : null}
 
@@ -438,13 +776,20 @@ export function LoginForm({
                 disabled={isSubmitting}
                 className="mt-2 h-14 w-full rounded-[1.4rem] bg-primary text-lg font-semibold text-primary-foreground shadow-[0_20px_60px_rgba(45,201,142,0.18)] transition-transform duration-200 hover:-translate-y-0.5 hover:bg-primary/90"
               >
-                {isSubmitting ? "Signing In..." : "Sign In"}
+                {isSubmitting ? (isRegisterMode ? "Creating Account..." : "Signing In...") : isRegisterMode ? "Create Account" : "Sign In"}
                 <ArrowRight className="ml-2 h-5 w-5" />
               </Button>
             </form>
 
             <p className="mt-7 text-center text-base text-[var(--auth-soft-text)]">
-              Account required. Registration can be connected to Supabase Auth when production credentials are ready.
+              {isRegisterMode ? "Already have an account?" : "New to TaihuCasino?"}{" "}
+              <button
+                type="button"
+                onClick={() => switchAuthMode(isRegisterMode ? "sign-in" : "register")}
+                className="font-semibold text-primary hover:text-primary/80"
+              >
+                {isRegisterMode ? "Sign in" : "Create a member profile"}
+              </button>
             </p>
 
             <p className="mt-5 text-center text-xs leading-6 text-[var(--auth-faint-text)]">

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -12,10 +12,11 @@ export const metadata: Metadata = {
 export default async function LoginPage({
   searchParams,
 }: {
-  searchParams: Promise<{ next?: string }>
+  searchParams: Promise<{ mode?: string; next?: string }>
 }) {
   const params = await searchParams
   const testAccount = getLocalDemoCredentials()
+  const initialMode = params.mode === "register" ? "register" : "sign-in"
 
-  return <LoginForm next={params.next} testAccount={testAccount} />
+  return <LoginForm initialMode={initialMode} next={params.next} testAccount={testAccount} />
 }

--- a/lib/home-content.ts
+++ b/lib/home-content.ts
@@ -196,13 +196,13 @@ export function getQuickActions(language: Language, viewerMode: ViewerMode): Hom
     ? [
         { key: "start", label: "开始试玩", description: "从百家乐或轮盘开始进入大厅", href: getGameRoute("baccarat", language), variant: "primary" },
         { key: "blackjack", label: "试试 21 点", description: "给喜欢策略感的玩家准备的桌台", href: getGameRoute("blackjack", language) },
-        { key: "register", label: "创建玩家档案", description: "预留后续接入注册与会员能力", href: "#top" },
+        { key: "register", label: "创建玩家档案", description: "创建账号并初始化会员档案", href: "/login?mode=register" },
         { key: "guide", label: "了解玩法", description: "先看推荐与最近动态，再选择桌台", href: "#leaderboard" },
       ]
     : [
         { key: "start", label: "Start Playing", description: "Begin with Baccarat or Roulette", href: getGameRoute("baccarat", language), variant: "primary" },
         { key: "blackjack", label: "Try Blackjack", description: "A stronger strategy pick for new players", href: getGameRoute("blackjack", language) },
-        { key: "register", label: "Create Profile", description: "Reserved for future sign-up and member flow", href: "#top" },
+        { key: "register", label: "Create Profile", description: "Create an account and member profile", href: "/login?mode=register" },
         { key: "guide", label: "How To Start", description: "Check recommendations before choosing a table", href: "#leaderboard" },
       ]
 }

--- a/lib/member-session.ts
+++ b/lib/member-session.ts
@@ -6,7 +6,12 @@ export interface MemberSession {
   provider?: "supabase" | "local"
 }
 
-export type OAuthProviderKey = "google" | "apple" | "microsoft" | "facebook" | "x"
+export type OAuthProviderKey = "google" | "apple" | "microsoft" | "facebook" | "amazon" | "x"
+
+export interface RegisterMemberResult {
+  confirmationRequired: boolean
+  session: MemberSession | null
+}
 
 export async function loginMember(account: string, password: string): Promise<MemberSession> {
   const response = await fetch("/api/auth/login", {
@@ -29,29 +34,54 @@ export async function loginMember(account: string, password: string): Promise<Me
   return payload.session
 }
 
+export async function registerMember({
+  email,
+  password,
+  displayName,
+  next,
+  captchaToken,
+}: {
+  email: string
+  password: string
+  displayName: string
+  next?: string
+  captchaToken?: string
+}): Promise<RegisterMemberResult> {
+  const response = await fetch("/api/auth/register", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ email, password, displayName, next, captchaToken }),
+  })
+
+  const payload = (await response.json().catch(() => null)) as {
+    confirmationRequired?: boolean
+    session?: MemberSession | null
+    error?: string
+  } | null
+
+  if (!response.ok || !payload) {
+    throw new Error(payload?.error ?? "Unable to create account.")
+  }
+
+  return {
+    confirmationRequired: Boolean(payload.confirmationRequired),
+    session: payload.session ?? null,
+  }
+}
+
 export async function startOAuthSignIn(provider: OAuthProviderKey, next?: string) {
   if (typeof window === "undefined") {
     return
   }
 
-  const response = await fetch("/api/auth/oauth", {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-    },
-    body: JSON.stringify({ provider, next }),
-  })
-
-  const payload = (await response.json().catch(() => null)) as {
-    redirectTo?: string
-    error?: string
-  } | null
-
-  if (!response.ok || !payload?.redirectTo) {
-    throw new Error(payload?.error ?? "Unable to start sign in.")
+  const params = new URLSearchParams({ provider })
+  if (next) {
+    params.set("next", next)
   }
 
-  window.location.assign(payload.redirectTo)
+  window.location.href = `/api/auth/oauth?${params.toString()}`
 }
 
 export async function readMemberSession(): Promise<MemberSession | null> {


### PR DESCRIPTION
## 中文

### 变更
- 增加 Supabase 邮箱/密码注册 API，并在注册时传入 Turnstile captcha token。
- 登录页增加注册模式、玩家名称/确认密码字段、Turnstile 状态与重试体验。
- 首页创建档案入口指向真实注册路径。
- OAuth 入口支持 GET 跳转，并保留 Amazon 自定义 provider 映射。

### 验证
- corepack pnpm typecheck
- corepack pnpm build
- 用户已在本地完成真实注册并跑通一局游戏。

### 后续
- 邮箱验证 UX、SMTP/域名、重新发送验证邮件在 GHO-24/GHO-25 后续处理。
- Discord/Twitch 与 Amazon 登录继续由 GHO-28/GHO-27 跟进。

## English

### Changes
- Added Supabase email/password registration API with Turnstile captcha token forwarding.
- Added registration mode to the auth page with player name, confirm password, Turnstile status, and retry handling.
- Pointed homepage profile creation to the real registration route.
- Added GET OAuth redirect support and preserved the Amazon custom provider mapping.

### Verification
- corepack pnpm typecheck
- corepack pnpm build
- User manually verified real registration and completed one game locally.

### Follow-ups
- Email confirmation UX, SMTP/domain setup, and resend verification email remain in GHO-24/GHO-25.
- Discord/Twitch and Amazon login remain in GHO-28/GHO-27.

Closes GHO-26
Refs GHO-21