### PR TITLE
[codex] Harden deploy readiness checks / 强化部署就绪检查

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .obsidian/
 gcm-diagnose.log
-tsconfig.tsbuildinfo
+*.tsbuildinfo
 .preview-next*.log
 .preview-next*.err.log
 .playwright-cli/

--- a/README.md
+++ b/README.md
@@ -102,20 +102,36 @@ pnpm start
 
 ## Authentication Environment
 
-The formal Next.js product line uses Supabase Auth for member identity and SSR cookie sessions. Configure local and production environments with:
+The formal product line uses Supabase Auth for member identity and SSR cookie sessions.
 
-- `NEXT_PUBLIC_SUPABASE_URL`: Supabase project URL.
-- `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY`: Supabase publishable key. `NEXT_PUBLIC_SUPABASE_ANON_KEY` is accepted as a compatibility fallback.
+正式产品线使用 Supabase Auth 作为会员身份来源，并使用 SSR cookie session。
+
+Production deployments should configure:
+
+生产环境应配置：
+
+- `NEXT_PUBLIC_SUPABASE_URL`: Supabase project URL. / Supabase 项目 URL。
+- `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY`: Supabase publishable key. `NEXT_PUBLIC_SUPABASE_ANON_KEY` is accepted as a compatibility fallback. / Supabase publishable key。`NEXT_PUBLIC_SUPABASE_ANON_KEY` 可作为兼容回退。
+- `SUPABASE_SERVICE_ROLE_KEY`: server-only Supabase service role key used by member and wallet mutation paths. Never expose it through `NEXT_PUBLIC_*`. / 仅服务端使用的 Supabase service role key，用于会员和钱包写入路径。绝不能通过 `NEXT_PUBLIC_*` 暴露。
+- `TAIHU_SESSION_SECRET`: a long random secret used to sign fallback session cookies. / 用于签名回退 session cookie 的长随机密钥。
+- `NEXT_PUBLIC_TURNSTILE_SITE_KEY`: required when registration remains enabled with Cloudflare Turnstile. / 如果注册页继续启用 Cloudflare Turnstile，则需要配置。
+
+Supabase Auth production setup also needs Site URL, `/auth/callback` redirect allowlist, OAuth provider configuration, and CAPTCHA/Turnstile backend settings when registration is enabled. See `docs/DEPLOYMENT_READINESS.md`.
+
+Supabase Auth 生产设置还需要配置 Site URL、`/auth/callback` redirect allowlist、OAuth provider，以及启用注册时的 CAPTCHA/Turnstile 后台设置。详见 `docs/DEPLOYMENT_READINESS.md`。
 
 The app keeps a legacy local fallback for development when Supabase variables are absent:
 
-- `TAIHU_SESSION_SECRET`: a long random secret used to sign fallback session cookies.
-- `TAIHU_AUTH_ACCOUNT` and `TAIHU_AUTH_PASSWORD`: single-account fallback credentials, or
-- `TAIHU_AUTH_USERS`: JSON array of fallback user records, for example `[{"account":"member@example.com","password":"change-me","displayName":"Member"}]`.
+- `TAIHU_AUTH_ACCOUNT` and `TAIHU_AUTH_PASSWORD`: single-account fallback credentials. / 单个回退账号。
+- `TAIHU_AUTH_USERS`: JSON array of fallback user records, for example `[{"account":"member@example.com","password":"change-me","displayName":"Member"}]`. / 回退用户 JSON 数组，例如 `[{"account":"member@example.com","password":"change-me","displayName":"Member"}]`。
 
 Local development falls back to `demo@taihu.casino` / `taihu-demo-2026` when neither Supabase nor fallback auth env vars are set. Production deployments should configure Supabase Auth and should not rely on the fallback account.
 
-Supabase profile schema and RLS notes live in `docs/SUPABASE_AUTH_SCHEMA.md`. The initial SQL migration is `supabase/migrations/20260418_init_auth_profiles.sql`.
+当 Supabase 和回退账号变量都不存在时，本地开发会回退到 `demo@taihu.casino` / `taihu-demo-2026`。生产部署必须配置 Supabase Auth，不应依赖回退账号。
+
+Supabase profile schema, RLS notes, and member data boundary live in `docs/SUPABASE_AUTH_SCHEMA.md`. The initial SQL migration is `supabase/migrations/20260418_init_auth_profiles.sql`.
+
+Supabase profile schema、RLS 说明和会员数据边界见 `docs/SUPABASE_AUTH_SCHEMA.md`。初始 SQL migration 是 `supabase/migrations/20260418_init_auth_profiles.sql`。
 
 ## Temporary Test Branch Scope
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -4,6 +4,8 @@
 @custom-variant dark (&:is(.dark *));
 
 :root {
+  --font-inter: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-playfair: "Playfair Display", Georgia, Cambria, "Times New Roman", Times, serif;
   --background: oklch(0.985 0.008 95);
   --foreground: oklch(0.23 0.03 248);
   --card: oklch(0.995 0.004 95);
@@ -127,8 +129,8 @@
 }
 
 @theme inline {
-  --font-sans: var(--font-inter), 'Inter', system-ui, sans-serif;
-  --font-serif: var(--font-playfair), 'Playfair Display', Georgia, serif;
+  --font-sans: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-serif: "Playfair Display", Georgia, Cambria, "Times New Roman", Times, serif;
   --font-mono: 'Geist Mono', 'Geist Mono Fallback';
   --color-background: var(--background);
   --color-foreground: var(--foreground);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,18 +1,7 @@
 import type { Metadata } from 'next'
-import { Inter, Playfair_Display } from 'next/font/google'
 import { Analytics } from '@vercel/analytics/next'
 import { ThemeProvider } from '@/components/theme-provider'
 import './globals.css'
-
-const inter = Inter({ 
-  subsets: ["latin"],
-  variable: '--font-inter'
-});
-
-const playfair = Playfair_Display({ 
-  subsets: ["latin"],
-  variable: '--font-playfair'
-});
 
 export const metadata: Metadata = {
   title: 'TaihuCasino',
@@ -44,7 +33,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="zh-CN" suppressHydrationWarning className="bg-background">
-      <body className={`${inter.variable} ${playfair.variable} font-sans antialiased`}>
+      <body className="font-sans antialiased">
         <ThemeProvider attribute="class" defaultTheme="dark" enableSystem={false}>
           {children}
         </ThemeProvider>

--- a/docs/DEPLOYMENT_READINESS.md
+++ b/docs/DEPLOYMENT_READINESS.md
@@ -1,0 +1,135 @@
+# Deployment Readiness / 部署就绪说明
+
+Last updated: 2026-05-31
+
+## Scope / 范围
+
+This document covers the MVP deployment gate for the Next.js product line. It does not cover new gameplay, new monetization features, or a Three.js lobby redesign.
+
+本文档覆盖 Next.js 产品线的 MVP 部署检查口径。不包含新玩法、新付费功能或 Three.js 大厅重设计。
+
+## Local Commands / 本地命令
+
+Use Corepack so the repository-pinned `pnpm` version is used.
+
+使用 Corepack，确保本地使用仓库指定的 `pnpm` 版本。
+
+```powershell
+corepack pnpm install
+corepack pnpm typecheck
+corepack pnpm build
+corepack pnpm dev
+```
+
+The combined CI gate is available as:
+
+组合 CI 检查命令：
+
+```powershell
+corepack pnpm run ci
+```
+
+`pnpm typecheck` runs `next typegen` before `tsc --noEmit -p tsconfig.typecheck.json`. This refreshes Next.js route and layout type definitions while keeping the deploy-readiness check focused on `.next/types` instead of stale `.next/dev` output from a previous dev server. The base `tsconfig.json` also excludes `.next/dev` so production builds are not affected by old dev-server type artifacts.
+
+`pnpm typecheck` 会先执行 `next typegen`，再执行 `tsc --noEmit -p tsconfig.typecheck.json`。这样可以刷新 Next.js 路由和布局类型，同时让部署检查只关注 `.next/types`，避免旧 dev server 生成的 `.next/dev` 类型产物干扰。基础 `tsconfig.json` 也排除了 `.next/dev`，防止生产构建被旧开发产物影响。
+
+## Build Determinism / 构建确定性
+
+The root layout does not import fonts from `next/font/google`. Font families are defined as CSS font stacks in `app/globals.css`, so `next build` does not require network access to Google Fonts.
+
+根布局不再从 `next/font/google` 导入字体。字体由 `app/globals.css` 中的 CSS fallback 栈提供，因此 `next build` 不再依赖 Google Fonts 网络请求。
+
+For MVP deploy readiness, this branch accepts possible visual fallback from Inter or Playfair Display to system fonts. If brand typography fidelity becomes a launch requirement, self-host `.woff2` font files and use `next/font/local` or `@font-face` in a separate visual polish branch.
+
+在 MVP 部署就绪阶段，本分支接受 Inter 或 Playfair Display 缺失时回退到系统字体的视觉差异。如果上线前需要严格保持品牌字体效果，应在单独的视觉打磨分支中自托管 `.woff2` 字体，并使用 `next/font/local` 或 `@font-face`。
+
+## Node.js Runtime / Node.js 运行时
+
+CI currently runs with Node.js 24. Use Node.js 24 for local verification and non-Vercel hosting parity.
+
+当前 CI 使用 Node.js 24。为了和 CI 以及非 Vercel 托管环境保持一致，本地验证和生产托管建议使用 Node.js 24。
+
+## Production Environment Variables / 生产环境变量
+
+Required for Supabase-backed production auth and member APIs:
+
+Supabase 生产认证和会员 API 必需变量：
+
+- `NEXT_PUBLIC_SUPABASE_URL`: Supabase project URL. / Supabase 项目 URL。
+- `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY`: Supabase publishable key. `NEXT_PUBLIC_SUPABASE_ANON_KEY` is accepted as a compatibility fallback. / Supabase publishable key。`NEXT_PUBLIC_SUPABASE_ANON_KEY` 可作为兼容回退。
+- `SUPABASE_SERVICE_ROLE_KEY`: Supabase service role key used only by server-side member and wallet mutation paths. Never expose it to the browser. / Supabase service role key，仅用于服务端会员和钱包写入路径，绝不能暴露到浏览器。
+- `TAIHU_SESSION_SECRET`: long random secret for signing fallback member session cookies. Configure it in production so legacy/fallback cookie paths cannot fail open or use development defaults. / 用于签名回退会员 session cookie 的长随机密钥。生产环境必须配置，避免 legacy/fallback cookie 路径使用开发默认值或异常。
+
+Required when registration remains enabled with Cloudflare Turnstile:
+
+如果注册页继续启用 Cloudflare Turnstile，还需要：
+
+- `NEXT_PUBLIC_TURNSTILE_SITE_KEY`: Turnstile site key used by the registration form. / 注册表单使用的 Turnstile site key。
+
+Development-only fallback auth:
+
+仅限本地开发的回退账号：
+
+- `TAIHU_AUTH_ACCOUNT` and `TAIHU_AUTH_PASSWORD`: one fallback account. / 单个回退账号。
+- `TAIHU_AUTH_USERS`: JSON array of fallback users, for example `[{"account":"member@example.com","password":"change-me","displayName":"Member"}]`. / 回退用户 JSON 数组，例如 `[{"account":"member@example.com","password":"change-me","displayName":"Member"}]`。
+
+Optional development/testing switch:
+
+可选开发/测试开关：
+
+- `TAIHU_ENABLE_TEST_WALLET_TOPUP`: enables the test wallet top-up endpoint in production only when explicitly set to `true`. Keep it unset or false for normal production deployments. / 仅在显式设置为 `true` 时允许生产环境测试充值入口。常规生产部署应保持未设置或 false。
+
+When Supabase variables are missing, local development can use the built-in demo account or the `TAIHU_AUTH_*` fallback. Production deployments should configure Supabase and should not rely on demo or fallback credentials.
+
+当 Supabase 变量缺失时，本地开发可以使用内置 demo 账号或 `TAIHU_AUTH_*` 回退账号。生产部署必须配置 Supabase，不应依赖 demo 或回退账号。
+
+## Supabase Auth Production Checklist / Supabase Auth 生产配置清单
+
+Environment variables alone are not enough. Before promoting a production deployment, configure Supabase Auth and provider settings.
+
+仅配置环境变量还不够。生产发布前，还需要配置 Supabase Auth 和第三方登录提供商。
+
+- Set the Supabase Auth Site URL to the production origin. / 将 Supabase Auth Site URL 设置为生产域名。
+- Add the production `/auth/callback` URL to the redirect allowlist. Add preview URLs if preview OAuth testing is required. / 将生产环境 `/auth/callback` 加入 redirect allowlist。如需在预览环境测试 OAuth，也加入预览 URL。
+- Configure OAuth providers used by the login page: Google, Apple, Microsoft/Azure, Facebook, and X. Amazon is disabled in the current app. / 配置登录页使用的 OAuth provider：Google、Apple、Microsoft/Azure、Facebook 和 X。当前应用中 Amazon 已禁用。
+- If registration is enabled, configure Supabase CAPTCHA/Turnstile backend settings in addition to `NEXT_PUBLIC_TURNSTILE_SITE_KEY`. The registration API passes `captchaToken` to `supabase.auth.signUp`. / 如果启用注册，除 `NEXT_PUBLIC_TURNSTILE_SITE_KEY` 外，还要配置 Supabase CAPTCHA/Turnstile 后台设置。注册 API 会把 `captchaToken` 传给 `supabase.auth.signUp`。
+- Apply the Supabase migrations in `supabase/migrations/` before testing member, wallet, table session, ad reward, purchase, and game round APIs. / 在测试会员、钱包、桌台 session、广告奖励、购买和游戏回合 API 前，先应用 `supabase/migrations/` 中的迁移。
+- Keep `SUPABASE_SERVICE_ROLE_KEY` server-only. It is required by server-side member and wallet mutation code paths, but must never be exposed in `NEXT_PUBLIC_*` variables. / `SUPABASE_SERVICE_ROLE_KEY` 必须只存在于服务端环境。服务端会员和钱包写入路径需要它，但绝不能放进 `NEXT_PUBLIC_*` 变量。
+
+## Hosting Notes / 托管说明
+
+Vercel can deploy this app as a zero-config Next.js project. Configure the production environment variables above in the Vercel project settings before promoting a production deployment.
+
+Vercel 可以按零配置 Next.js 项目部署此应用。正式发布前，需要先在 Vercel 项目设置中配置上面的生产环境变量。
+
+For another Node-compatible host, run:
+
+如果使用其他兼容 Node.js 的托管平台，运行：
+
+```powershell
+corepack pnpm build
+corepack pnpm start
+```
+
+The host must provide Node.js 24 for parity with CI and must keep server-only environment variables out of client bundles.
+
+托管平台应提供 Node.js 24，以保持和 CI 一致，并确保服务端专用环境变量不会进入客户端 bundle。
+
+## Final Gate / 最终检查
+
+Before opening or merging a deploy-readiness PR, run:
+
+在打开或合并部署就绪 PR 前，运行：
+
+```powershell
+corepack pnpm run ci
+git status --short --branch
+```
+
+`corepack pnpm run ci` runs the same typecheck and production build gates.
+
+`corepack pnpm run ci` 会执行同一套类型检查和生产构建 gate。
+
+The branch should have only intentional source and documentation changes. Generated `.next` output and TypeScript build info files should remain untracked.
+
+分支中应只包含有意提交的源码和文档变更。生成的 `.next` 产物和 TypeScript build info 文件不应进入版本控制。

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@ All formal documents should be bilingual in English and Chinese.
 
 ## Engineering / 工程文档
 
+- `DEPLOYMENT_READINESS.md`
 - `TECH_STACK_DECISION.md`
 - `AUTH0_MEMBER_COUNTER_SETUP.md`
 - `subagent-peer-review.md`

--- a/docs/SUPABASE_AUTH_SCHEMA.md
+++ b/docs/SUPABASE_AUTH_SCHEMA.md
@@ -19,11 +19,20 @@ Set these variables in local and deployment environments:
 ```env
 NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=
+SUPABASE_SERVICE_ROLE_KEY=
+TAIHU_SESSION_SECRET=
+NEXT_PUBLIC_TURNSTILE_SITE_KEY=
 ```
 
-`NEXT_PUBLIC_SUPABASE_ANON_KEY` is also accepted as a compatibility fallback. Use `SUPABASE_SERVICE_ROLE_KEY` only for future server-only admin tasks; it is not required for the current login/session flow.
+`NEXT_PUBLIC_SUPABASE_ANON_KEY` is also accepted as a compatibility fallback. `SUPABASE_SERVICE_ROLE_KEY` is not required for the auth/session handshake itself, but it is required by current server-side member and wallet mutation paths. Keep it server-only and never expose it through `NEXT_PUBLIC_*`. `TAIHU_SESSION_SECRET` signs fallback session cookies and should be set in production so fallback paths never use local development defaults.
+
+`NEXT_PUBLIC_SUPABASE_ANON_KEY` 也可作为兼容回退。`SUPABASE_SERVICE_ROLE_KEY` 不是登录/session 握手本身的必需项，但当前服务端会员和钱包写入路径需要它。该变量必须只存在于服务端环境，绝不能通过 `NEXT_PUBLIC_*` 暴露。`TAIHU_SESSION_SECRET` 用于签名回退 session cookie，生产环境应配置它，避免回退路径使用本地开发默认值。
 
 If Supabase variables are missing, local development can still use the legacy demo account path from `TAIHU_AUTH_*`. Production should configure Supabase and should not rely on the legacy fallback.
+
+If registration remains enabled, configure both `NEXT_PUBLIC_TURNSTILE_SITE_KEY` and Supabase Auth CAPTCHA/Turnstile backend settings. Production OAuth also requires the Supabase Site URL, `/auth/callback` redirect allowlist, and the enabled provider credentials.
+
+如果注册页继续启用，需要同时配置 `NEXT_PUBLIC_TURNSTILE_SITE_KEY` 和 Supabase Auth CAPTCHA/Turnstile 后台设置。生产 OAuth 还需要配置 Supabase Site URL、`/auth/callback` redirect allowlist，以及已启用 provider 的凭据。
 
 ## Profile Boundary
 
@@ -62,7 +71,9 @@ It creates member-owned tables for the new member center and migrated game route
 - `public.member_game_progress`: per-game plays, wins, losses, streaks, bankroll, and latest settlement summary.
 - `public.member_events`: short audit/event stream for member-facing activity.
 
-All four tables enable RLS and only allow authenticated users to read, insert, or update rows where `auth.uid() = user_id`. The app deliberately does not use a service role for normal member reads/writes.
+All four tables enable RLS and only allow authenticated users to read, insert, or update rows where `auth.uid() = user_id`. Normal profile/settings/progress reads and writes stay user-scoped. Current wallet and member mutation paths that need trusted server-side writes use `SUPABASE_SERVICE_ROLE_KEY` through server-only code.
+
+这四张表都启用 RLS，只允许已登录用户读写 `auth.uid() = user_id` 的行。普通 profile/settings/progress 读写仍然保持用户作用域。当前需要可信服务端写入的钱包和会员 mutation 路径，会通过服务端代码使用 `SUPABASE_SERVICE_ROLE_KEY`。
 
 The API contract is:
 

--- a/package.json
+++ b/package.json
@@ -3,13 +3,16 @@
   "version": "0.1.0",
   "private": true,
   "packageManager": "pnpm@10.33.0",
+  "engines": {
+    "node": ">=24 <25"
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
     "lint": "eslint .",
-    "typecheck": "tsc --noEmit",
-    "ci": "npm run typecheck && npm run build"
+    "typecheck": "next typegen && tsc --noEmit -p tsconfig.typecheck.json",
+    "ci": "corepack pnpm typecheck && corepack pnpm build"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -36,6 +36,7 @@
     ".next/dev/types/**/*.ts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    ".next/dev"
   ]
 }

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "incremental": false
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    ".next/dev"
+  ]
+}


### PR DESCRIPTION
## Summary / 变更摘要

- Remove the `next/font/google` build-time network dependency and use deterministic CSS font stacks.  
  移除 `next/font/google` 的构建期网络依赖，改用确定性的 CSS 字体 fallback 栈。
- Make typechecking regenerate Next.js route types while excluding stale `.next/dev` artifacts.  
  类型检查会重新生成 Next.js 路由类型，并排除陈旧的 `.next/dev` 产物。
- Align the combined CI script and runtime policy around Corepack, pnpm, and Node.js 24.  
  将组合 CI 脚本和运行时策略统一到 Corepack、pnpm 与 Node.js 24。
- Add bilingual deploy-readiness guidance covering required environment variables, Supabase Auth, OAuth redirects, Turnstile/CAPTCHA, migrations, and final gates.  
  新增中英双语部署就绪文档，覆盖必需环境变量、Supabase Auth、OAuth 回调、Turnstile/CAPTCHA、数据库迁移和最终检查。

## Why / 原因

The MVP had two practical deployment risks: production builds could depend on Google Fonts network access, and direct TypeScript checks could be affected by stale generated Next.js dev types. Deployment documentation also did not consistently describe the current server-side service-role and authentication configuration requirements.

MVP 当前存在两个实际部署风险：生产构建可能依赖 Google Fonts 网络访问；直接运行 TypeScript 检查可能受到陈旧 Next.js dev 类型产物影响。同时，现有部署文档没有一致说明当前服务端 service role 和认证配置要求。

## Accepted Risk / 已接受风险

This PR intentionally accepts system-font fallback for MVP deploy readiness. Devices without Inter or Playfair Display installed may render with system UI or Georgia, which can slightly change typography and wrapping. Self-hosted `.woff2` fonts should be handled later in a dedicated visual-polish branch if strict brand typography becomes a launch requirement.

为了优先完成 MVP 部署就绪，本 PR 明确接受系统字体 fallback。未安装 Inter 或 Playfair Display 的设备可能回退到 system UI 或 Georgia，字体观感和换行可能略有变化。如果上线前需要严格保持品牌字体，应在后续独立视觉打磨分支中自托管 `.woff2` 字体。

## Validation / 验证

- `corepack pnpm run ci`
  - `next typegen` passed / 通过
  - `tsc --noEmit -p tsconfig.typecheck.json` passed / 通过
  - `next build` passed and generated all 40 static pages / 通过并生成全部 40 个静态页面
- `git diff --cached --check` passed before commit / 提交前检查通过
- Verified with Node.js `v24.14.1` / 使用 Node.js `v24.14.1` 验证
- GitHub CI and Vercel Preview passed / GitHub CI 与 Vercel Preview 已通过

## Scope Note / 范围说明

Unrelated Wiki/Delivery Hub working-tree changes were deliberately excluded from this PR.

与本次部署就绪无关的 Wiki/Delivery Hub 工作树改动已明确排除，不包含在本 PR 中。