### PR TITLE
[codex] Add bilingual delivery wiki / 新增双语交付 Wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ This restructure did two main things:
 - `TypeScript`
 - `Tailwind CSS 4`
 
+## Delivery Hub / 协作入口
+
+- Project board / 项目看板: [TaihuCasino Delivery](https://github.com/users/GHOST-AKU/projects/2)
+- Wiki / 流程与手册入口: [TaihuCasino Wiki](https://github.com/GHOST-AKU/TaihuCasino/wiki)
+- Wiki source in repo / 仓库内 Wiki 源文件: [`docs/wiki/Home.md`](./docs/wiki/Home.md)
+- Backlog bootstrap issues / 首批 backlog: [Open backlog items](https://github.com/GHOST-AKU/TaihuCasino/issues?q=is%3Aissue%20is%3Aopen%20no%3Aassignee)
+
 ## Main Directories / 主要目录
 
 ```text

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ All formal documents should be bilingual in English and Chinese.
 
 - `DOCUMENT_BILINGUAL_AUDIT.md` - bilingual documentation status and next batches  
   `DOCUMENT_BILINGUAL_AUDIT.md` - 双语文档状态与后续处理批次
+- `wiki/Home.md` - wiki-ready navigation pages for workflow and release operations / 面向 Wiki 的流程与发布导航页面
 - `PROJECT_STRUCTURE_CLEAN.md` - quick project structure reference  
   `PROJECT_STRUCTURE_CLEAN.md` - 项目结构快速参考
 - `CODEBASE_BOUNDARY_PLAN.md` - formal boundary and migration plan  

--- a/docs/wiki/Architecture-Map.md
+++ b/docs/wiki/Architecture-Map.md
@@ -1,0 +1,30 @@
+# Architecture Map / 架构地图
+
+TaihuCasino currently runs a dual-track architecture: formal Next.js product line + legacy static runtime during migration.
+
+TaihuCasino 当前是双轨架构：正式 Next.js 产品线 + 迁移期遗留静态运行层。
+
+## Core Boundaries / 核心边界
+
+- `app/`: formal App Router entry and APIs / 正式 App Router 入口和 API
+- `components/`: shared UI and page shells / 共享 UI 和页面外壳
+- `lib/`: data access, auth helpers, shared logic / 数据访问、认证辅助和共享逻辑
+- `supabase/migrations/`: schema and database evolution / 数据库结构与迁移历史
+- `pages/`, `assets/`: legacy runtime kept for migration compatibility / 为迁移兼容保留的遗留运行层
+
+## Current Hot Paths / 当前关键路径
+
+- Auth flow: login/register/oauth/callback / 认证流程：登录、注册、OAuth、回调
+- Member APIs: profile/settings/progress/wallet/table sessions / 会员 API：资料、设置、进度、钱包、桌台 session
+- Game routes: baccarat/blackjack/roulette/dice and related settlements / 游戏路由：百家乐、二十一点、轮盘、骰子及相关结算
+
+## Migration Direction / 迁移方向
+
+- New product work goes to `app/` and shared React components. / 新产品工作进入 `app/` 和共享 React 组件。
+- Legacy pages are maintained only as temporary compatibility layer. / 遗留页面仅作为临时兼容层维护。
+
+## References / 参考文档
+
+- [Codebase Boundary Plan](../CODEBASE_BOUNDARY_PLAN.md)
+- [Project Structure Clean](../PROJECT_STRUCTURE_CLEAN.md)
+- [Supabase Auth Schema](../SUPABASE_AUTH_SCHEMA.md)

--- a/docs/wiki/Getting-Started.md
+++ b/docs/wiki/Getting-Started.md
@@ -1,0 +1,33 @@
+# Getting Started / 快速开始
+
+Use this page as the quick-start entry for local development and routine checks.
+
+本页用于本地开发启动与日常检查的快速入口。
+
+## Environment / 环境与命令
+
+1. Install dependencies / 安装依赖
+   ```powershell
+   corepack pnpm install
+   ```
+2. Start dev server / 启动开发服务器
+   ```powershell
+   corepack pnpm dev
+   ```
+3. Run the combined CI gate / 运行组合 CI 检查
+   ```powershell
+   corepack pnpm run ci
+   ```
+
+## Where To Work / 开发位置
+
+- Product routes / 产品路由: `app/`
+- Shared UI/components / 共享 UI 和组件: `components/`
+- Utility and shared logic / 工具与共享逻辑: `lib/`
+- Legacy runtime, migration target / 遗留运行层与迁移目标: `pages/`, `assets/`
+
+## References / 参考文档
+
+- [README](../../README.md)
+- [Project Structure](../PROJECT_STRUCTURE.md)
+- [Deployment Readiness](../DEPLOYMENT_READINESS.md)

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -1,0 +1,19 @@
+# TaihuCasino Wiki Home / Wiki 首页
+
+This wiki is the stable navigation entry for delivery workflow and team operations. Deep technical details remain versioned in `docs/` inside the main repository.
+
+本页面是交付流程与团队协作的稳定导航入口。详细技术文档继续在主仓库 `docs/` 中版本化维护。
+
+## Pages / 页面
+
+- [Getting Started / 快速开始](./Getting-Started.md): local setup and common commands / 本地启动与常用命令
+- [Workflow / 工作流](./Workflow.md): issue-to-PR delivery flow / Issue 到 PR 的协作流程
+- [Architecture Map / 架构地图](./Architecture-Map.md): codebase boundaries and module map / 代码边界与模块地图
+- [Release Checklist / 发布清单](./Release-Checklist.md): release and rollback checklist / 发布与回滚清单
+
+## Deep Docs In Repository / 仓库内详细文档
+
+- [Deployment Readiness](../DEPLOYMENT_READINESS.md)
+- [Supabase Auth Schema](../SUPABASE_AUTH_SCHEMA.md)
+- [Codebase Boundary Plan](../CODEBASE_BOUNDARY_PLAN.md)
+- [Theme System](../THEME_SYSTEM.md)

--- a/docs/wiki/Release-Checklist.md
+++ b/docs/wiki/Release-Checklist.md
@@ -1,0 +1,39 @@
+# Release Checklist / 发布清单
+
+Use this checklist before production release and during rollback decisions.
+
+发布前与回滚决策时使用本清单。
+
+## Pre-release / 发布前
+
+- [ ] Required env vars are present and verified. / 必需环境变量已配置并验证。
+- [ ] `corepack pnpm run ci` passes. / `corepack pnpm run ci` 已通过。
+- [ ] Auth callback URLs and provider configs are correct. / 认证回调 URL 和 provider 配置正确。
+- [ ] Critical member flows smoke-tested. / 关键会员流程已完成 smoke test：
+  - login/register / 登录与注册
+  - table buy-in / 桌台买入
+  - round settlement / 回合结算
+  - cash-out / 离桌结算
+
+## Deployment / 部署
+
+- [ ] Confirm target branch/tag and release notes. / 确认目标分支、tag 和发布说明。
+- [ ] Deploy and monitor server/runtime logs for error spikes. / 部署并监控服务端和运行时日志的异常峰值。
+- [ ] Validate core API endpoints after deployment. / 部署后验证核心 API。
+
+## Rollback Triggers / 回滚触发条件
+
+- Repeated auth failures / 持续认证失败
+- Wallet/session settlement inconsistencies / 钱包或 session 结算不一致
+- Sustained high-severity API errors / 持续出现高严重度 API 错误
+
+## Rollback Steps / 回滚步骤
+
+1. Revert to last known good deployment. / 回退到最近已知正常部署。
+2. Re-run post-deploy smoke checks. / 重新执行部署后 smoke test。
+3. Announce incident summary and follow-up actions. / 发布事故摘要和后续行动。
+
+## References / 参考文档
+
+- [Deployment Readiness](../DEPLOYMENT_READINESS.md)
+- [Supabase Auth Schema](../SUPABASE_AUTH_SCHEMA.md)

--- a/docs/wiki/Workflow.md
+++ b/docs/wiki/Workflow.md
@@ -1,0 +1,34 @@
+# Workflow / 工作流
+
+This page defines the default delivery loop from planning to merge.
+
+本页定义从计划到合并的默认交付流程。
+
+## Issue -> PR -> Review -> Merge / Issue 到合并
+
+1. Create or refine an issue with required sections. / 创建或完善 Issue，包含必需部分：
+   - Goal / 目标
+   - Scope / 范围
+   - Acceptance / 验收标准
+   - Out of scope / 非目标
+2. Move the issue into the active queue. / 将 Issue 移入活跃队列。
+3. Open a PR with bilingual summary and verification steps. / 创建包含中英双语摘要和验证步骤的 PR。
+4. Address review comments and rerun checks. / 处理评审意见并重新运行检查。
+5. Merge only after acceptance criteria are met. / 仅在满足验收标准后合并。
+
+## Required PR Content / PR 必需内容
+
+- What changed / 变更内容
+- Verification / 验证步骤
+- Follow-ups / 后续项（if any）
+
+## Review Expectations / 评审要求
+
+- Changes must align with issue scope. / 改动必须符合 Issue 范围。
+- Include test/build evidence for behavioral changes. / 行为变更必须提供测试或构建证据。
+- Keep unrelated refactors out of scope unless necessary. / 除非必要，不要混入无关重构。
+
+## References / 参考文档
+
+- [CONTRIBUTING](../../CONTRIBUTING.md)
+- [Docs Index](../README.md)


### PR DESCRIPTION
## Summary / 变更摘要

- Add a bilingual Delivery Hub to the root README with links to the project board, Wiki, repository Wiki source, and backlog issues.  
  在根 README 中新增中英双语协作入口，链接项目看板、Wiki、仓库内 Wiki 源文件和 backlog Issues。
- Add five bilingual Wiki-ready pages covering getting started, workflow, architecture, release, and navigation.  
  新增五份可用于 Wiki 的中英双语页面，覆盖快速开始、工作流、架构、发布和导航。
- Add the Wiki source entry to the documentation index.  
  在文档索引中增加 Wiki 源文件入口。
- Align development and release commands with the repository's Corepack/pnpm deploy-readiness convention.  
  将开发与发布命令统一到仓库的 Corepack/pnpm 部署就绪规范。

## Why / 原因

The project already has delivery workflows, architecture guidance, and release checks distributed across the repository, but it lacked a concise operational navigation layer. This PR creates a version-controlled, bilingual source of truth that can also be published to GitHub Wiki.

项目已经在仓库中分散维护交付流程、架构说明和发布检查，但缺少简洁的协作导航层。本 PR 建立一套受版本控制的中英双语入口，并可作为 GitHub Wiki 的发布源文件。

## Pages / 页面

- `docs/wiki/Home.md`
- `docs/wiki/Getting-Started.md`
- `docs/wiki/Workflow.md`
- `docs/wiki/Architecture-Map.md`
- `docs/wiki/Release-Checklist.md`

## Validation / 验证

- `corepack pnpm run ci` passed / 已通过
  - `next typegen` passed / 已通过
  - TypeScript check passed / 类型检查已通过
  - production build passed and generated all 40 static pages / 生产构建已通过并生成全部 40 个静态页面
- `git diff --cached --check` passed / 已通过
- Verified all referenced repository files exist / 已确认所有引用的仓库文件均存在

## Follow-up / 后续

These files are the version-controlled Wiki source. Publishing or synchronizing them to the GitHub Wiki itself remains a separate operational step.

这些文件是受版本控制的 Wiki 源文件。将其发布或同步到 GitHub Wiki 页面仍是单独的运营步骤。