### PR TITLE
⚡ fix(gameplay): speed up baccarat presentation / 加快百家乐展示节奏

### DIFF
--- a/components/baccarat-table-page.tsx
+++ b/components/baccarat-table-page.tsx
@@ -158,9 +158,9 @@ const betOptions = [
   tone: "player" | "banker" | "tie"
 }>
 
-const dealCardDelayMs = 680
-const pointCheckDelayMs = 900
-const settlementDelayMs = 1700
+const dealCardDelayMs = 220
+const pointCheckDelayMs = 250
+const settlementDelayMs = 200
 
 const suits = ["spades", "hearts", "diamonds", "clubs"] satisfies Suit[]
 
@@ -867,7 +867,7 @@ export function BaccaratTablePage({
     for (let index = 0; index < steps.length; index += 1) {
       const step = steps[index]
 
-      await sleep(index === 0 ? 360 : dealCardDelayMs)
+      await sleep(index === 0 ? 160 : dealCardDelayMs)
       setVisibleDeal({
         playerCards: step.playerCards,
         bankerCards: step.bankerCards,

--- a/tests/authoritative-settlement.test.mjs
+++ b/tests/authoritative-settlement.test.mjs
@@ -104,3 +104,26 @@ test("client contracts and database migration close direct-write boundaries", as
   assert.match(migration, /revoke insert, update on table public\.member_game_progress from authenticated/)
   assert.match(migration, /revoke insert on table public\.member_events from authenticated/)
 })
+
+test("baccarat presentation settles a six-card hand within two seconds", async () => {
+  const source = await readFile(new URL("../components/baccarat-table-page.tsx", import.meta.url), "utf8")
+  const readDelay = (name) => {
+    const match = source.match(new RegExp(`const ${name} = (\\d+)`))
+    assert.ok(match, `${name} must remain an explicit timing constant`)
+    return Number(match[1])
+  }
+  const initialDealMatch = source.match(/index === 0 \? (\d+) : dealCardDelayMs/)
+  assert.ok(initialDealMatch, "initial deal delay must remain explicit")
+
+  const initialDealDelay = Number(initialDealMatch[1])
+  const dealCardDelay = readDelay("dealCardDelayMs")
+  const pointCheckDelay = readDelay("pointCheckDelayMs")
+  const settlementDelay = readDelay("settlementDelayMs")
+  const sixCardPresentationDelay = initialDealDelay
+    + (5 * dealCardDelay)
+    + pointCheckDelay
+    + settlementDelay
+
+  assert.ok(settlementDelay <= 300, `final settlement pause is ${settlementDelay}ms`)
+  assert.ok(sixCardPresentationDelay <= 2000, `six-card presentation takes ${sixCardPresentationDelay}ms`)
+})


### PR DESCRIPTION
## Summary / 概要

### English
- Shortens Baccarat dealing, point-check, and settlement pauses so even a six-card hand completes its presentation in under two seconds.

### 中文
- 缩短百家乐发牌、点数检查和结算停顿，使六张牌局面的展示也能在两秒内完成。

## Changes / 改动内容

### English
- Reduced the initial deal delay and per-card delay.
- Reduced point-check and final settlement pauses.
- Added a regression test that enforces the two-second presentation budget.

### 中文
- 缩短首次发牌和逐张发牌延迟。
- 缩短点数检查和最终结算等待时间。
- 新增回归测试，约束完整展示时长不超过两秒。

## Testing / 测试情况

### English
- [x] `corepack pnpm typecheck`
- [x] `corepack pnpm exec node --test tests/authoritative-settlement.test.mjs` (7 passed)
- [x] `corepack pnpm build`

### 中文
- [x] TypeScript 类型检查通过
- [x] 权威结算测试 7 项全部通过
- [x] 生产构建通过

## Notes / 备注

### English
- This PR changes presentation timing only; game rules and authoritative settlement behavior remain unchanged.

### 中文
- 本 PR 仅调整展示节奏，不改变游戏规则与服务端权威结算逻辑。