### PR TITLE
🔐 feat(auth): add modal CAPTCHA password recovery / 增加弹窗验证码密码找回

### DIFF
--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -19,10 +19,12 @@ export async function POST(request: Request) {
   const body = (await request.json().catch(() => null)) as {
     account?: unknown
     password?: unknown
+    captchaToken?: unknown
   } | null
 
   const account = typeof body?.account === "string" ? body.account.trim() : ""
   const password = typeof body?.password === "string" ? body.password : ""
+  const captchaToken = typeof body?.captchaToken === "string" ? body.captchaToken.trim() : ""
   observer.info("auth.login.started", { userIdentifier: account })
 
   if (!account || !password) {
@@ -44,6 +46,11 @@ export async function POST(request: Request) {
   }
 
   if (isSupabaseAuthConfigured()) {
+    if (!captchaToken) {
+      observer.reject("auth.login.rejected", { status: 400, reasonCode: "missing_captcha", userIdentifier: account })
+      return observer.attach(NextResponse.json({ error: "Please complete the security check." }, { status: 400 }))
+    }
+
     try {
       assertSupabaseAuthConfigured()
 
@@ -60,6 +67,7 @@ export async function POST(request: Request) {
       const { data, error } = await supabase.auth.signInWithPassword({
         email: account,
         password,
+        options: { captchaToken },
       })
 
       if (error || !data.user) {

--- a/app/api/auth/password-reset/request/route.ts
+++ b/app/api/auth/password-reset/request/route.ts
@@ -1,0 +1,55 @@
+import { cookies } from "next/headers"
+import { NextResponse } from "next/server"
+
+import { enforceRateLimit } from "@/lib/rate-limit"
+import { createSupabaseAuthClient, isSupabaseAuthConfigured } from "@/lib/server-auth"
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+const ACCEPTED_MESSAGE = "If an account exists for this email, a password reset link is on its way."
+
+export async function POST(request: Request) {
+  const body = (await request.json().catch(() => null)) as { email?: unknown; captchaToken?: unknown } | null
+  const email = typeof body?.email === "string" ? body.email.trim().toLowerCase() : ""
+  const captchaToken = typeof body?.captchaToken === "string" ? body.captchaToken.trim() : ""
+
+  if (!EMAIL_PATTERN.test(email)) {
+    return NextResponse.json({ error: "Enter a valid email address." }, { status: 400 })
+  }
+
+  if (!captchaToken) {
+    return NextResponse.json({ error: "Please complete the security check." }, { status: 400 })
+  }
+
+  if (!isSupabaseAuthConfigured()) {
+    return NextResponse.json(
+      { error: "Password recovery is not configured." },
+      { status: 501, headers: { "cache-control": "private, no-store" } },
+    )
+  }
+
+  const limited = await enforceRateLimit(request, "auth.password-reset-request", { identifiers: [email] })
+  if (limited) return limited
+
+  const response = NextResponse.json(
+    { message: ACCEPTED_MESSAGE },
+    { status: 202, headers: { "cache-control": "private, no-store" } },
+  )
+  const cookieStore = await cookies()
+  const supabase = createSupabaseAuthClient(cookieStore, response)
+  const origin = new URL(request.url).origin
+
+  // The response stays identical for known and unknown addresses to prevent account enumeration.
+  const { error } = await supabase.auth.resetPasswordForEmail(email, {
+    captchaToken,
+    redirectTo: `${origin}/auth/callback?next=${encodeURIComponent("/reset-password")}`,
+  })
+
+  if (error) {
+    return NextResponse.json(
+      { error: "The reset email could not be sent. Please wait a moment and try again." },
+      { status: 502, headers: response.headers },
+    )
+  }
+
+  return response
+}

--- a/app/api/auth/password-reset/update/route.ts
+++ b/app/api/auth/password-reset/update/route.ts
@@ -1,0 +1,60 @@
+import { cookies } from "next/headers"
+import { NextResponse } from "next/server"
+
+import { enforceRateLimit } from "@/lib/rate-limit"
+import { isSameOriginRequest } from "@/lib/request-origin"
+import { createSupabaseAuthClient, isSupabaseAuthConfigured } from "@/lib/server-auth"
+
+const MIN_PASSWORD_LENGTH = 8
+const MAX_PASSWORD_LENGTH = 1024
+
+export async function POST(request: Request) {
+  if (!isSameOriginRequest(request)) {
+    return NextResponse.json({ error: "Cross-origin mutation rejected." }, { status: 403 })
+  }
+
+  const body = (await request.json().catch(() => null)) as { password?: unknown } | null
+  const password = typeof body?.password === "string" ? body.password : ""
+
+  if (password.length < MIN_PASSWORD_LENGTH) {
+    return NextResponse.json({ error: "Password must be at least 8 characters." }, { status: 400 })
+  }
+  if (password.length > MAX_PASSWORD_LENGTH) {
+    return NextResponse.json({ error: "Password is too long." }, { status: 400 })
+  }
+  if (!isSupabaseAuthConfigured()) {
+    return NextResponse.json(
+      { error: "Password recovery is not configured." },
+      { status: 501, headers: { "cache-control": "private, no-store" } },
+    )
+  }
+
+  const limited = await enforceRateLimit(request, "auth.password-reset-update")
+  if (limited) return limited
+
+  const response = NextResponse.json(
+    { updated: true },
+    { headers: { "cache-control": "private, no-store" } },
+  )
+  const cookieStore = await cookies()
+  const supabase = createSupabaseAuthClient(cookieStore, response)
+  const { data: userData, error: userError } = await supabase.auth.getUser()
+
+  if (userError || !userData.user) {
+    return NextResponse.json(
+      { error: "This password reset link is invalid or has expired." },
+      { status: 401, headers: response.headers },
+    )
+  }
+
+  const { error: updateError } = await supabase.auth.updateUser({ password })
+  if (updateError) {
+    return NextResponse.json(
+      { error: "Password could not be updated. Choose a different password and try again." },
+      { status: 400, headers: response.headers },
+    )
+  }
+
+  await supabase.auth.signOut({ scope: "global" })
+  return response
+}

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -5,19 +5,27 @@ import { createSupabaseAuthClient, createSupabaseServiceClient, isSupabaseAuthCo
 import { AGE_ATTESTATION_VERSION, PRIVACY_VERSION, TERMS_VERSION } from "@/lib/legal"
 
 function resolveRedirectTarget(nextTarget: string | null) {
-  if (!nextTarget?.startsWith("/")) {
+  if (!nextTarget?.startsWith("/") || nextTarget.startsWith("//")) {
     return "/"
   }
 
-  return nextTarget.startsWith("//") ? "/" : nextTarget
+  return nextTarget
+}
+
+function recoveryErrorUrl(origin: string) {
+  return new URL("/forgot-password?error=invalid_link", origin)
 }
 
 export async function GET(request: Request) {
   const requestUrl = new URL(request.url)
   const redirectTarget = resolveRedirectTarget(requestUrl.searchParams.get("next"))
   const code = requestUrl.searchParams.get("code")
+  const isPasswordRecovery = redirectTarget === "/reset-password"
 
   if (!isSupabaseAuthConfigured() || !code) {
+    if (isPasswordRecovery) {
+      return NextResponse.redirect(recoveryErrorUrl(requestUrl.origin))
+    }
     return NextResponse.redirect(new URL(`/login?next=${encodeURIComponent(redirectTarget)}`, requestUrl.origin))
   }
 
@@ -31,6 +39,9 @@ export async function GET(request: Request) {
   const { data, error } = await supabase.auth.exchangeCodeForSession(code)
 
   if (error) {
+    if (isPasswordRecovery) {
+      return NextResponse.redirect(recoveryErrorUrl(requestUrl.origin))
+    }
     return NextResponse.redirect(
       new URL(`/login?next=${encodeURIComponent(redirectTarget)}&authError=oauth`, requestUrl.origin),
     )

--- a/app/auth/confirm/route.ts
+++ b/app/auth/confirm/route.ts
@@ -1,0 +1,30 @@
+import type { EmailOtpType } from "@supabase/supabase-js"
+import { cookies } from "next/headers"
+import { NextResponse } from "next/server"
+
+import { createSupabaseAuthClient, isSupabaseAuthConfigured } from "@/lib/server-auth"
+
+function recoveryErrorUrl(origin: string) {
+  return new URL("/forgot-password?error=invalid_link", origin)
+}
+
+export async function GET(request: Request) {
+  const requestUrl = new URL(request.url)
+  const tokenHash = requestUrl.searchParams.get("token_hash")
+  const type = requestUrl.searchParams.get("type")
+
+  if (!isSupabaseAuthConfigured() || !tokenHash || type !== "recovery") {
+    return NextResponse.redirect(recoveryErrorUrl(requestUrl.origin))
+  }
+
+  const response = NextResponse.redirect(new URL("/reset-password", requestUrl.origin), {
+    headers: { "cache-control": "private, no-store" },
+  })
+  const supabase = createSupabaseAuthClient(await cookies(), response)
+  const { error } = await supabase.auth.verifyOtp({
+    token_hash: tokenHash,
+    type: type as EmailOtpType,
+  })
+
+  return error ? NextResponse.redirect(recoveryErrorUrl(requestUrl.origin)) : response
+}

--- a/app/forgot-password/forgot-password-form.tsx
+++ b/app/forgot-password/forgot-password-form.tsx
@@ -1,0 +1,120 @@
+"use client"
+
+import Link from "next/link"
+import { ArrowLeft, Mail } from "lucide-react"
+import { useEffect, useRef, useState } from "react"
+
+import { CaptchaDialog } from "@/components/captcha-dialog"
+import { PasswordRecoveryShell } from "@/components/password-recovery-shell"
+import { Button } from "@/components/ui/button"
+import { requestPasswordReset } from "@/lib/member-session"
+
+export function ForgotPasswordForm({ invalidLink = false }: { invalidLink?: boolean }) {
+  const [email, setEmail] = useState("")
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [errorMessage, setErrorMessage] = useState(invalidLink ? "That reset link is invalid or has expired. Request a new one." : "")
+  const [isComplete, setIsComplete] = useState(false)
+  const [captchaToken, setCaptchaToken] = useState("")
+  const [captchaDialogOpen, setCaptchaDialogOpen] = useState(false)
+  const [captchaResetKey, setCaptchaResetKey] = useState(0)
+  const formRef = useRef<HTMLFormElement | null>(null)
+  const submitAfterCaptchaRef = useRef(false)
+
+  useEffect(() => {
+    if (!captchaToken || !submitAfterCaptchaRef.current) {
+      return
+    }
+
+    submitAfterCaptchaRef.current = false
+    setCaptchaDialogOpen(false)
+    formRef.current?.requestSubmit()
+  }, [captchaToken])
+
+  function resetCaptcha() {
+    setCaptchaToken("")
+    setCaptchaResetKey((current) => current + 1)
+    setCaptchaDialogOpen(true)
+  }
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    setErrorMessage("")
+
+    if (!captchaToken) {
+      setErrorMessage("Complete the security check in the pop-up to continue.")
+      submitAfterCaptchaRef.current = true
+      setCaptchaDialogOpen(true)
+      return
+    }
+
+    setIsSubmitting(true)
+
+    try {
+      await requestPasswordReset(email.trim(), captchaToken)
+      setIsComplete(true)
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : "Unable to start password recovery.")
+      resetCaptcha()
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <>
+      <PasswordRecoveryShell
+        title={isComplete ? "Check your email" : "Recover access"}
+        description={isComplete ? "Use the secure link we sent to continue." : "Enter the email address linked to your member account."}
+      >
+      {isComplete ? (
+        <div className="space-y-6 text-center">
+          <div className="rounded-[1.25rem] border border-primary/20 bg-primary/10 px-5 py-4 text-sm leading-6 text-[var(--auth-soft-text)]">
+            If an account exists for <strong className="text-foreground">{email.trim()}</strong>, a reset link is on its way. Check spam if it does not arrive.
+          </div>
+          <Button asChild className="h-12 w-full rounded-[1.1rem] text-base">
+            <Link href="/login">Return to sign in</Link>
+          </Button>
+        </div>
+      ) : (
+        <form ref={formRef} onSubmit={handleSubmit} className="space-y-5">
+          <label htmlFor="recovery-email" className="block">
+            <span className="mb-2.5 block text-sm font-semibold text-foreground">Email address</span>
+            <span className="casino-auth-field flex h-14 items-center rounded-[1.25rem] border px-4 focus-within:border-primary/35">
+              <Mail className="mr-3 h-5 w-5 text-[var(--auth-faint-text)]" />
+              <input
+                id="recovery-email"
+                type="email"
+                required
+                autoFocus
+                autoComplete="email"
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+                placeholder="you@example.com"
+                className="h-full w-full bg-transparent text-base text-foreground outline-none placeholder:text-[var(--auth-faint-text)]"
+              />
+            </span>
+          </label>
+
+          <CaptchaDialog
+            open={captchaDialogOpen}
+            onOpenChange={setCaptchaDialogOpen}
+            token={captchaToken}
+            onTokenChange={setCaptchaToken}
+            resetKey={captchaResetKey}
+          />
+
+          {errorMessage ? <p role="alert" className="rounded-xl border border-destructive/25 bg-destructive/10 px-4 py-3 text-sm text-destructive">{errorMessage}</p> : null}
+
+          <Button type="submit" disabled={isSubmitting} className="h-12 w-full rounded-[1.1rem] text-base">
+            {isSubmitting ? "Sending secure link..." : "Send reset link"}
+          </Button>
+
+          <Link href="/login" className="flex items-center justify-center gap-2 text-sm font-semibold text-primary hover:text-primary/80">
+            <ArrowLeft className="h-4 w-4" /> Back to sign in
+          </Link>
+        </form>
+      )}
+      </PasswordRecoveryShell>
+    </>
+  )
+}

--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from "next"
+
+import { ForgotPasswordForm } from "./forgot-password-form"
+
+export const metadata: Metadata = {
+  title: "Forgot password | TaihuCasino",
+  description: "Request a secure password reset link for your TaihuCasino member account.",
+}
+
+export default async function ForgotPasswordPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ error?: string }>
+}) {
+  const params = await searchParams
+  return <ForgotPasswordForm invalidLink={params.error === "invalid_link"} />
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -67,6 +67,76 @@
   --auth-faint-text: rgba(100, 116, 139, 0.88);
 }
 
+@media (min-width: 1024px) and (max-height: 1000px) {
+  .casino-auth-form-shell {
+    padding-block: 1rem;
+  }
+
+  .casino-auth-panel {
+    padding: 1.25rem;
+  }
+
+  .casino-auth-heading h2 {
+    font-size: 2.1rem;
+    line-height: 1.1;
+  }
+
+  .casino-auth-heading p {
+    margin-top: 0.375rem;
+  }
+
+  .casino-auth-mode-tabs,
+  .casino-auth-test-account,
+  .casino-auth-consent {
+    margin-top: 1rem;
+  }
+
+  .casino-auth-mode-tabs button {
+    height: 2.75rem;
+  }
+
+  .casino-auth-test-account,
+  .casino-auth-consent {
+    padding: 0.75rem;
+  }
+
+  .casino-auth-consent {
+    gap: 0.5rem;
+    font-size: 0.8rem;
+    line-height: 1.15rem;
+  }
+
+  .casino-auth-providers {
+    margin-top: 0.75rem;
+    gap: 0.75rem;
+  }
+
+  .casino-auth-providers button {
+    height: 3rem;
+  }
+
+  .casino-auth-desktop-optional {
+    display: none;
+  }
+
+  .casino-auth-email-form {
+    margin-top: 1rem;
+  }
+
+  .casino-auth-email-form > :not(:first-child) {
+    margin-top: 0.75rem;
+  }
+
+  .casino-auth-email-form label > div:first-child {
+    margin-bottom: 0.375rem;
+  }
+
+  .casino-auth-email-form .casino-auth-field,
+  .casino-auth-email-form button[type="submit"] {
+    height: 3rem;
+  }
+}
+
 .dark {
   --background: oklch(0.12 0.01 260);
   --foreground: oklch(0.95 0 0);

--- a/app/login/login-form.tsx
+++ b/app/login/login-form.tsx
@@ -2,11 +2,11 @@
 
 import Link from "next/link"
 import Image from "next/image"
-import Script from "next/script"
 import { useEffect, useRef, useState } from "react"
 import { useRouter } from "next/navigation"
 import { ArrowRight, Eye, EyeOff, Lock, Mail, Spade, UserPlus } from "lucide-react"
 
+import { CaptchaDialog, isCaptchaConfigured } from "@/components/captcha-dialog"
 import { Button } from "@/components/ui/button"
 import { loginMember, readMemberSession, registerMember, startOAuthSignIn, type OAuthProviderKey } from "@/lib/member-session"
 import { cn } from "@/lib/utils"
@@ -73,30 +73,6 @@ const stats = [
   { value: "Clear", label: "Explainable play" },
 ]
 
-const turnstileSiteKey = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY ?? ""
-
-declare global {
-  interface Window {
-    turnstile?: {
-      render: (
-        container: HTMLElement,
-        options: {
-          sitekey: string
-          appearance?: "always" | "execute" | "interaction-only"
-          theme?: "auto" | "light" | "dark"
-          size?: "normal" | "compact" | "flexible" | "invisible"
-          callback: (token: string) => void
-          "expired-callback": () => void
-          "error-callback": () => void
-        },
-      ) => string
-      getResponse?: (widgetId?: string) => string
-      reset: (widgetId?: string) => void
-      remove?: (widgetId: string) => void
-    }
-  }
-}
-
 interface TestAccountHint {
   account: string
   password: string
@@ -104,7 +80,6 @@ interface TestAccountHint {
 }
 
 type AuthMode = "sign-in" | "register"
-type CaptchaStatus = "idle" | "loading" | "verified" | "expired" | "error"
 
 function resolveRedirectTarget(nextTarget: string | null) {
   if (!nextTarget || !nextTarget.startsWith("/")) {
@@ -230,40 +205,16 @@ export function LoginForm({
   const [statusMessage, setStatusMessage] = useState("")
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [captchaToken, setCaptchaToken] = useState("")
-  const [captchaStatus, setCaptchaStatus] = useState<CaptchaStatus>("idle")
-  const [turnstileReady, setTurnstileReady] = useState(false)
-  const turnstileContainerRef = useRef<HTMLDivElement | null>(null)
-  const turnstileWidgetIdRef = useRef<string | null>(null)
+  const [captchaDialogOpen, setCaptchaDialogOpen] = useState(false)
+  const [captchaResetKey, setCaptchaResetKey] = useState(0)
+  const formRef = useRef<HTMLFormElement | null>(null)
+  const submitAfterCaptchaRef = useRef(false)
   const isRegisterMode = authMode === "register"
 
   function resetCaptcha() {
     setCaptchaToken("")
-    setCaptchaStatus(isRegisterMode && turnstileSiteKey ? "loading" : "idle")
-
-    if (turnstileWidgetIdRef.current && window.turnstile) {
-      window.turnstile.reset(turnstileWidgetIdRef.current)
-      return
-    }
-
-    if (isRegisterMode && typeof window !== "undefined") {
-      window.location.reload()
-    }
-  }
-
-  function readCaptchaTokenFromWidget() {
-    const widgetResponse = turnstileWidgetIdRef.current
-      ? (window.turnstile?.getResponse?.(turnstileWidgetIdRef.current)?.trim() ?? "")
-      : ""
-
-    if (widgetResponse) {
-      return widgetResponse
-    }
-
-    const hiddenInput = turnstileContainerRef.current?.querySelector<HTMLInputElement>(
-      'input[name="cf-turnstile-response"]',
-    )
-
-    return hiddenInput?.value.trim() ?? ""
+    setCaptchaResetKey((current) => current + 1)
+    setCaptchaDialogOpen(true)
   }
 
   useEffect(() => {
@@ -281,76 +232,22 @@ export function LoginForm({
   }, [next, router])
 
   useEffect(() => {
-    if (!isRegisterMode) {
-      setCaptchaToken("")
-      setCaptchaStatus("idle")
+    if (!captchaToken || !submitAfterCaptchaRef.current) {
       return
     }
 
-    if (!turnstileReady || !turnstileSiteKey || !turnstileContainerRef.current || !window.turnstile) {
-      setCaptchaStatus(turnstileSiteKey ? "loading" : "idle")
-      return
-    }
-
-    setCaptchaStatus("loading")
-    turnstileWidgetIdRef.current = window.turnstile.render(turnstileContainerRef.current, {
-      sitekey: turnstileSiteKey,
-      appearance: "always",
-      theme: "light",
-      size: "normal",
-      callback(token) {
-        setCaptchaToken(token)
-        setCaptchaStatus("verified")
-      },
-      "expired-callback"() {
-        setCaptchaToken("")
-        setCaptchaStatus("expired")
-      },
-      "error-callback"() {
-        setCaptchaToken("")
-        setCaptchaStatus("error")
-      },
-    })
-
-    return () => {
-      if (turnstileWidgetIdRef.current && window.turnstile?.remove) {
-        window.turnstile.remove(turnstileWidgetIdRef.current)
-      }
-      turnstileWidgetIdRef.current = null
-    }
-  }, [isRegisterMode, turnstileReady])
-
-  useEffect(() => {
-    if (!isRegisterMode || !turnstileSiteKey || captchaToken) {
-      return
-    }
-
-    const startedAt = Date.now()
-    const tokenCheck = window.setInterval(() => {
-      const activeCaptchaToken = readCaptchaTokenFromWidget()
-
-      if (activeCaptchaToken) {
-        setCaptchaToken(activeCaptchaToken)
-        setCaptchaStatus("verified")
-        window.clearInterval(tokenCheck)
-        return
-      }
-
-      if (Date.now() - startedAt > 9000) {
-        setCaptchaStatus("error")
-        window.clearInterval(tokenCheck)
-      }
-    }, 500)
-
-    return () => {
-      window.clearInterval(tokenCheck)
-    }
-  }, [captchaToken, isRegisterMode, turnstileReady])
+    submitAfterCaptchaRef.current = false
+    setCaptchaDialogOpen(false)
+    formRef.current?.requestSubmit()
+  }, [captchaToken])
 
   function switchAuthMode(mode: AuthMode) {
     setAuthMode(mode)
     setErrorMessage("")
     setStatusMessage("")
+    setCaptchaToken("")
+    setCaptchaResetKey((current) => current + 1)
+    submitAfterCaptchaRef.current = false
 
     const params = new URLSearchParams()
     if (mode === "register") {
@@ -395,21 +292,18 @@ export function LoginForm({
         return
       }
 
-      if (!turnstileSiteKey) {
+      if (!isCaptchaConfigured) {
         setErrorMessage("Security check is not configured.")
         return
       }
 
-      const activeCaptchaToken = captchaToken || readCaptchaTokenFromWidget()
+      const activeCaptchaToken = captchaToken
 
       if (!activeCaptchaToken) {
-        setErrorMessage("Please complete the security check.")
+        setErrorMessage("Complete the security check in the pop-up to continue.")
+        submitAfterCaptchaRef.current = true
+        setCaptchaDialogOpen(true)
         return
-      }
-
-      if (!captchaToken) {
-        setCaptchaToken(activeCaptchaToken)
-        setCaptchaStatus("verified")
       }
 
       setErrorMessage("")
@@ -459,17 +353,30 @@ export function LoginForm({
       return
     }
 
+    if (!isCaptchaConfigured) {
+      setErrorMessage("Security check is not configured.")
+      return
+    }
+
+    const activeCaptchaToken = captchaToken
+    if (!activeCaptchaToken) {
+      setErrorMessage("Complete the security check in the pop-up to continue.")
+      submitAfterCaptchaRef.current = true
+      setCaptchaDialogOpen(true)
+      return
+    }
+
     setErrorMessage("")
     setStatusMessage("")
-    resetCaptcha()
     setIsSubmitting(true)
 
     try {
-      await loginMember(trimmedEmail, password)
+      await loginMember(trimmedEmail, password, activeCaptchaToken)
       router.push(resolveRedirectTarget(next ?? null))
       router.refresh()
     } catch (error) {
       setErrorMessage(error instanceof Error ? error.message : "Unable to sign in.")
+      resetCaptcha()
     } finally {
       setIsSubmitting(false)
     }
@@ -506,16 +413,6 @@ export function LoginForm({
 
   return (
     <main className="casino-auth-shell relative min-h-screen overflow-hidden">
-      {isRegisterMode && turnstileSiteKey ? (
-        <Script
-          src="https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit"
-          strategy="afterInteractive"
-          onLoad={() => setTurnstileReady(true)}
-          onReady={() => setTurnstileReady(true)}
-          onError={() => setCaptchaStatus("error")}
-        />
-      ) : null}
-
       <div className="pointer-events-none absolute inset-0">
         <div className="lobby-ambient-orb absolute left-0 top-0 h-80 w-80 rounded-full blur-3xl" />
         <div className="lobby-ambient-orb lobby-ambient-orb-secondary absolute bottom-0 right-0 h-96 w-96 rounded-full blur-3xl" />
@@ -575,7 +472,7 @@ export function LoginForm({
           </div>
         </section>
 
-        <section className="relative flex min-h-screen items-center justify-center overflow-hidden px-5 py-24 sm:px-8 lg:px-10">
+        <section className="casino-auth-form-shell relative flex min-h-screen items-center justify-center overflow-hidden px-5 py-24 sm:px-8 lg:px-10">
           <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_0%,rgba(29,188,130,0.08),transparent_0_24%)]" />
 
           <div className="casino-auth-panel relative z-10 w-full max-w-[33rem] rounded-[2rem] p-6 sm:p-8">
@@ -588,7 +485,7 @@ export function LoginForm({
               </Link>
             </div>
 
-            <div className="text-center">
+            <div className="casino-auth-heading text-center">
               <h2 className="font-serif text-[2.55rem] font-semibold tracking-tight text-foreground">
                 {isRegisterMode ? "Create Account" : "Welcome Back"}
               </h2>
@@ -597,7 +494,7 @@ export function LoginForm({
               </p>
             </div>
 
-            <div className="mt-6 grid grid-cols-2 rounded-[1.25rem] border border-primary/15 bg-background/45 p-1">
+            <div className="casino-auth-mode-tabs mt-6 grid grid-cols-2 rounded-[1.25rem] border border-primary/15 bg-background/45 p-1">
               <button
                 type="button"
                 onClick={() => switchAuthMode("sign-in")}
@@ -621,7 +518,7 @@ export function LoginForm({
             </div>
 
             {testAccount && !isRegisterMode ? (
-              <div className="mt-6 rounded-[1.35rem] border border-primary/20 bg-primary/10 p-4 text-left">
+              <div className="casino-auth-test-account mt-6 rounded-[1.35rem] border border-primary/20 bg-primary/10 p-4 text-left">
                 <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                   <div>
                     <p className="text-sm font-semibold text-foreground">Test account</p>
@@ -636,7 +533,7 @@ export function LoginForm({
               </div>
             ) : null}
 
-            <div className="mt-6 space-y-3 rounded-[1.2rem] border border-primary/15 bg-background/50 px-4 py-4 text-sm text-[var(--auth-soft-text)]">
+            <div className="casino-auth-consent mt-6 space-y-3 rounded-[1.2rem] border border-primary/15 bg-background/50 px-4 py-4 text-sm text-[var(--auth-soft-text)]">
               <label className="flex items-start gap-3">
                 <input type="checkbox" checked={termsAccepted} onChange={(event) => setTermsAccepted(event.target.checked)} className="mt-1 h-4 w-4 accent-[var(--primary)]" />
                 <span>I accept the draft <Link href="/terms" className="text-primary underline">Terms</Link> and <Link href="/privacy" className="text-primary underline">Privacy framework</Link>.</span>
@@ -647,7 +544,7 @@ export function LoginForm({
               </label>
             </div>
 
-            <div className="mt-5 grid grid-cols-3 gap-3">
+            <div className="casino-auth-providers mt-5 grid grid-cols-3 gap-3">
               {providerButtons.map((provider) => (
                 <ProviderButton
                   key={provider.key}
@@ -663,17 +560,17 @@ export function LoginForm({
               ))}
             </div>
 
-            <p className="mt-4 text-center text-sm leading-6 text-[var(--auth-soft-text)]">
+            <p className="casino-auth-desktop-optional mt-4 text-center text-sm leading-6 text-[var(--auth-soft-text)]">
               First-time social sign-in automatically creates a Taihu member profile.
             </p>
 
-            <div className="my-7 flex items-center gap-4 text-sm text-[var(--auth-faint-text)]">
+            <div className="casino-auth-desktop-optional my-7 flex items-center gap-4 text-sm text-[var(--auth-faint-text)]">
               <div className="h-px flex-1 bg-[var(--auth-divider)]" />
               <span className="text-base">{isRegisterMode ? "or create with email" : "or continue with email"}</span>
               <div className="h-px flex-1 bg-[var(--auth-divider)]" />
             </div>
 
-            <form onSubmit={handleSubmit} className="space-y-4">
+            <form ref={formRef} onSubmit={handleSubmit} className="casino-auth-email-form space-y-4">
               {isRegisterMode ? (
                 <Field
                   id="displayName"
@@ -709,7 +606,7 @@ export function LoginForm({
                 icon={<Lock className="h-5 w-5" />}
                 action={
                   !isRegisterMode ? (
-                  <Link href="#" className="text-sm font-medium text-primary hover:text-primary/80">
+                  <Link href="/forgot-password" className="text-sm font-medium text-primary hover:text-primary/80">
                     Forgot password?
                   </Link>
                   ) : null
@@ -739,37 +636,13 @@ export function LoginForm({
                 />
               ) : null}
 
-              {isRegisterMode ? (
-                <div className="rounded-[1.2rem] border border-primary/15 bg-background/50 px-4 py-3">
-                  {turnstileSiteKey ? (
-                    <div className="space-y-2">
-                      <div ref={turnstileContainerRef} className="min-h-[65px]" />
-                      {captchaStatus === "loading" ? (
-                        <p className="text-xs font-medium text-[var(--auth-soft-text)]">Loading security check...</p>
-                      ) : null}
-                      {captchaStatus === "verified" ? (
-                        <p className="text-xs font-semibold text-primary">Security check complete.</p>
-                      ) : null}
-                      {captchaStatus === "expired" || captchaStatus === "error" ? (
-                        <div className="flex items-center justify-between gap-3">
-                          <p className="text-xs font-medium text-red-700 dark:text-red-200">
-                            {captchaStatus === "expired" ? "Security check expired." : "Security check failed."}
-                          </p>
-                          <button
-                            type="button"
-                            onClick={resetCaptcha}
-                            className="text-xs font-semibold text-primary hover:text-primary/80"
-                          >
-                            Retry
-                          </button>
-                        </div>
-                      ) : null}
-                    </div>
-                  ) : (
-                    <p className="text-sm text-red-700 dark:text-red-200">Security check is not configured.</p>
-                  )}
-                </div>
-              ) : null}
+              <CaptchaDialog
+                open={captchaDialogOpen}
+                onOpenChange={setCaptchaDialogOpen}
+                token={captchaToken}
+                onTokenChange={setCaptchaToken}
+                resetKey={captchaResetKey}
+              />
 
               {errorMessage ? (
                 <div className="rounded-[1.2rem] border border-red-500/25 bg-red-500/10 px-4 py-3 text-sm text-red-700 dark:text-red-200">
@@ -793,7 +666,7 @@ export function LoginForm({
               </Button>
             </form>
 
-            <p className="mt-7 text-center text-base text-[var(--auth-soft-text)]">
+            <p className="casino-auth-desktop-optional mt-7 text-center text-base text-[var(--auth-soft-text)]">
               {isRegisterMode ? "Already have an account?" : "New to TaihuCasino?"}{" "}
               <button
                 type="button"
@@ -804,7 +677,7 @@ export function LoginForm({
               </button>
             </p>
 
-            <p className="mt-5 text-center text-xs leading-6 text-[var(--auth-faint-text)]">
+            <p className="casino-auth-desktop-optional mt-5 text-center text-xs leading-6 text-[var(--auth-faint-text)]">
               By using TaihuCasino, you acknowledge our draft{" "}
               <Link href="/terms" className="underline underline-offset-4 hover:text-foreground">
                 Terms of Service

--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next"
+
+import { ResetPasswordForm } from "./reset-password-form"
+
+export const metadata: Metadata = {
+  title: "Set new password | TaihuCasino",
+  description: "Choose a new password for your TaihuCasino member account.",
+}
+
+export default function ResetPasswordPage() {
+  return <ResetPasswordForm />
+}

--- a/app/reset-password/reset-password-form.tsx
+++ b/app/reset-password/reset-password-form.tsx
@@ -1,0 +1,91 @@
+"use client"
+
+import Link from "next/link"
+import { CheckCircle2, Eye, EyeOff, Lock } from "lucide-react"
+import { useState } from "react"
+
+import { PasswordRecoveryShell } from "@/components/password-recovery-shell"
+import { Button } from "@/components/ui/button"
+import { updateMemberPassword } from "@/lib/member-session"
+
+export function ResetPasswordForm() {
+  const [password, setPassword] = useState("")
+  const [confirmation, setConfirmation] = useState("")
+  const [showPassword, setShowPassword] = useState(false)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [errorMessage, setErrorMessage] = useState("")
+  const [isComplete, setIsComplete] = useState(false)
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    if (password.length < 8) {
+      setErrorMessage("Password must be at least 8 characters.")
+      return
+    }
+    if (password !== confirmation) {
+      setErrorMessage("Passwords do not match.")
+      return
+    }
+
+    setErrorMessage("")
+    setIsSubmitting(true)
+    try {
+      await updateMemberPassword(password)
+      setIsComplete(true)
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : "Unable to update your password.")
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <PasswordRecoveryShell
+      title={isComplete ? "Password updated" : "Set a new password"}
+      description={isComplete ? "Your recovery session has been closed securely." : "Choose at least 8 characters that you do not reuse elsewhere."}
+    >
+      {isComplete ? (
+        <div className="space-y-6 text-center">
+          <CheckCircle2 className="mx-auto h-12 w-12 text-primary" />
+          <Button asChild className="h-12 w-full rounded-[1.1rem] text-base">
+            <Link href="/login">Sign in with new password</Link>
+          </Button>
+        </div>
+      ) : (
+        <form onSubmit={handleSubmit} noValidate className="space-y-5">
+          {[
+            { id: "new-password", label: "New password", value: password, setter: setPassword },
+            { id: "confirm-password", label: "Confirm new password", value: confirmation, setter: setConfirmation },
+          ].map((field) => (
+            <div key={field.id}>
+              <label htmlFor={field.id} className="mb-2.5 block text-sm font-semibold text-foreground">{field.label}</label>
+              <span className="casino-auth-field flex h-14 items-center rounded-[1.25rem] border px-4 focus-within:border-primary/35">
+                <Lock className="mr-3 h-5 w-5 text-[var(--auth-faint-text)]" />
+                <input
+                  id={field.id}
+                  type={showPassword ? "text" : "password"}
+                  required
+                  minLength={8}
+                  autoComplete="new-password"
+                  value={field.value}
+                  onChange={(event) => field.setter(event.target.value)}
+                  className="h-full w-full bg-transparent text-base text-foreground outline-none"
+                />
+                <button type="button" onClick={() => setShowPassword((current) => !current)} aria-label={showPassword ? "Hide passwords" : "Show passwords"} className="ml-3 text-[var(--auth-faint-text)] hover:text-foreground">
+                  {showPassword ? <EyeOff className="h-5 w-5" /> : <Eye className="h-5 w-5" />}
+                </button>
+              </span>
+            </div>
+          ))}
+
+          {errorMessage ? <p role="alert" className="rounded-xl border border-destructive/25 bg-destructive/10 px-4 py-3 text-sm text-destructive">{errorMessage}</p> : null}
+
+          <Button type="submit" disabled={isSubmitting} className="h-12 w-full rounded-[1.1rem] text-base">
+            {isSubmitting ? "Updating password..." : "Update password"}
+          </Button>
+          <Link href="/forgot-password" className="block text-center text-sm font-semibold text-primary hover:text-primary/80">Request a new link</Link>
+        </form>
+      )}
+    </PasswordRecoveryShell>
+  )
+}

--- a/components/captcha-dialog.tsx
+++ b/components/captcha-dialog.tsx
@@ -1,0 +1,279 @@
+"use client"
+
+import Script from "next/script"
+import { RotateCcw, ShieldCheck } from "lucide-react"
+import { useCallback, useEffect, useRef, useState } from "react"
+
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+
+const turnstileSiteKey = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY ?? ""
+
+export const isCaptchaConfigured = Boolean(turnstileSiteKey)
+
+type CaptchaStatus = "idle" | "loading" | "verified" | "expired" | "error"
+
+interface TurnstileApi {
+  render: (
+    container: HTMLElement,
+    options: {
+      sitekey: string
+      appearance: "always"
+      theme: "light"
+      size: "normal"
+      callback: (token: string) => void
+      "expired-callback": () => void
+      "error-callback": () => void
+    },
+  ) => string
+  getResponse?: (widgetId?: string) => string
+  reset: (widgetId?: string) => void
+  remove?: (widgetId: string) => void
+}
+
+declare global {
+  interface Window {
+    turnstile?: TurnstileApi
+  }
+}
+
+function getTurnstile() {
+  return window.turnstile
+}
+
+export function CaptchaDialog({
+  open,
+  onOpenChange,
+  token,
+  onTokenChange,
+  resetKey = 0,
+  className,
+}: {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  token: string
+  onTokenChange: (token: string) => void
+  resetKey?: number
+  className?: string
+}) {
+  const [captchaStatus, setCaptchaStatus] = useState<CaptchaStatus>(isCaptchaConfigured ? "idle" : "error")
+  const [turnstileReady, setTurnstileReady] = useState(false)
+  const [turnstileContainer, setTurnstileContainer] = useState<HTMLDivElement | null>(null)
+  const turnstileWidgetIdRef = useRef<string | null>(null)
+  const acceptedTokenRef = useRef("")
+
+  const acceptToken = useCallback(
+    (rawToken: string) => {
+      const nextToken = rawToken.trim()
+      if (!nextToken || acceptedTokenRef.current === nextToken) {
+        return
+      }
+
+      acceptedTokenRef.current = nextToken
+      setCaptchaStatus("verified")
+      onTokenChange(nextToken)
+    },
+    [onTokenChange],
+  )
+
+  const readCaptchaTokenFromWidget = useCallback(() => {
+    const widgetResponse = turnstileWidgetIdRef.current
+      ? (getTurnstile()?.getResponse?.(turnstileWidgetIdRef.current)?.trim() ?? "")
+      : ""
+
+    if (widgetResponse) {
+      return widgetResponse
+    }
+
+    const hiddenInput = turnstileContainer?.querySelector<HTMLInputElement>(
+      'input[name="cf-turnstile-response"]',
+    )
+
+    return hiddenInput?.value.trim() ?? ""
+  }, [turnstileContainer])
+
+  const resetCaptcha = useCallback(() => {
+    acceptedTokenRef.current = ""
+    onTokenChange("")
+    setCaptchaStatus(isCaptchaConfigured ? "loading" : "error")
+    getTurnstile()?.reset(turnstileWidgetIdRef.current ?? undefined)
+  }, [onTokenChange])
+
+  useEffect(() => {
+    if (token) {
+      setCaptchaStatus("verified")
+      return
+    }
+
+    acceptedTokenRef.current = ""
+    setCaptchaStatus(isCaptchaConfigured ? (open ? "loading" : "idle") : "error")
+  }, [open, token])
+
+  useEffect(() => {
+    if (resetKey === 0) {
+      return
+    }
+
+    resetCaptcha()
+  }, [resetKey, resetCaptcha])
+
+  useEffect(() => {
+    const turnstile = getTurnstile()
+    if (!open || !isCaptchaConfigured) {
+      return
+    }
+
+    if (!turnstileContainer || !turnstile) {
+      setCaptchaStatus("loading")
+      return
+    }
+
+    setCaptchaStatus("loading")
+    turnstileWidgetIdRef.current = turnstile.render(turnstileContainer, {
+      sitekey: turnstileSiteKey,
+      appearance: "always",
+      theme: "light",
+      size: "normal",
+      callback: acceptToken,
+      "expired-callback"() {
+        acceptedTokenRef.current = ""
+        onTokenChange("")
+        setCaptchaStatus("expired")
+      },
+      "error-callback"() {
+        acceptedTokenRef.current = ""
+        onTokenChange("")
+        setCaptchaStatus("error")
+      },
+    })
+
+    return () => {
+      if (turnstileWidgetIdRef.current) {
+        getTurnstile()?.remove?.(turnstileWidgetIdRef.current)
+      }
+      turnstileWidgetIdRef.current = null
+    }
+  }, [acceptToken, onTokenChange, open, turnstileContainer, turnstileReady])
+
+  useEffect(() => {
+    if (!open || token) {
+      return
+    }
+
+    const tokenCheck = window.setInterval(() => {
+      const activeCaptchaToken = readCaptchaTokenFromWidget()
+      if (activeCaptchaToken) {
+        acceptToken(activeCaptchaToken)
+        window.clearInterval(tokenCheck)
+      }
+    }, 500)
+
+    return () => {
+      window.clearInterval(tokenCheck)
+    }
+  }, [acceptToken, open, readCaptchaTokenFromWidget, token])
+
+  function openCaptchaDialog() {
+    setCaptchaStatus(isCaptchaConfigured ? (token ? "verified" : "loading") : "error")
+    onOpenChange(true)
+  }
+
+  const statusText = !isCaptchaConfigured
+    ? "Security check is not configured."
+    : token
+      ? "Security check complete."
+      : "Open the pop-up to complete the security check."
+
+  return (
+    <>
+      {isCaptchaConfigured ? (
+        <Script
+          src="https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit"
+          strategy="afterInteractive"
+          onLoad={() => setTurnstileReady(true)}
+          onReady={() => setTurnstileReady(true)}
+          onError={() => setCaptchaStatus("error")}
+        />
+      ) : null}
+
+      <div className={cn("rounded-[1.2rem] border border-primary/15 bg-background/50 px-4 py-3", className)}>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-center gap-3">
+            <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
+              <ShieldCheck className="h-5 w-5" />
+            </span>
+            <div>
+              <p className="text-sm font-semibold text-foreground">Security check</p>
+              <p className={cn("mt-1 text-xs", token ? "font-semibold text-primary" : "text-[var(--auth-soft-text)]")}>
+                {statusText}
+              </p>
+            </div>
+          </div>
+          <Button type="button" variant="outline" size="sm" disabled={!isCaptchaConfigured} onClick={openCaptchaDialog}>
+            {token ? "Redo check" : "Verify"}
+          </Button>
+        </div>
+      </div>
+
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent className="max-w-[25rem] rounded-[1.35rem] border-primary/15">
+          <DialogHeader>
+            <DialogTitle>Security check</DialogTitle>
+            <DialogDescription>Complete the verification in this pop-up before continuing.</DialogDescription>
+          </DialogHeader>
+
+          {isCaptchaConfigured ? (
+            <div className="space-y-3">
+              <div className="flex min-h-[76px] items-center justify-center rounded-[1rem] border border-primary/10 bg-background/60 px-2 py-3">
+                <div ref={setTurnstileContainer} className="min-h-[65px]" />
+              </div>
+              {captchaStatus === "loading" ? (
+                <p className="text-xs font-medium text-[var(--auth-soft-text)]">Loading security check...</p>
+              ) : null}
+              {captchaStatus === "verified" ? (
+                <p className="text-xs font-semibold text-primary">Security check complete.</p>
+              ) : null}
+              {captchaStatus === "expired" || captchaStatus === "error" ? (
+                <div className="rounded-xl border border-destructive/20 bg-destructive/10 px-3 py-2">
+                  <p className="text-xs font-medium text-destructive">
+                    {captchaStatus === "expired" ? "Security check expired." : "Security check failed."}
+                  </p>
+                </div>
+              ) : null}
+            </div>
+          ) : (
+            <p className="rounded-xl border border-destructive/25 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+              Security check is not configured.
+            </p>
+          )}
+
+          <DialogFooter>
+            {isCaptchaConfigured ? (
+              <Button type="button" variant="outline" onClick={resetCaptcha} className="gap-2">
+                <RotateCcw className="h-4 w-4" /> Retry
+              </Button>
+            ) : null}
+            <DialogClose asChild>
+              <Button
+                type="button"
+                variant={captchaStatus === "verified" ? "default" : "outline"}
+                disabled={isCaptchaConfigured && captchaStatus !== "verified"}
+              >
+                Done
+              </Button>
+            </DialogClose>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/components/password-recovery-shell.tsx
+++ b/components/password-recovery-shell.tsx
@@ -1,0 +1,71 @@
+import Link from "next/link"
+import { ShieldCheck, Spade } from "lucide-react"
+
+export function PasswordRecoveryShell({
+  title,
+  description,
+  children,
+}: {
+  title: string
+  description: string
+  children: React.ReactNode
+}) {
+  return (
+    <main className="casino-auth-shell relative min-h-screen overflow-hidden">
+      <div className="pointer-events-none absolute inset-0">
+        <div className="lobby-ambient-orb absolute left-0 top-0 h-80 w-80 rounded-full blur-3xl" />
+        <div className="lobby-ambient-orb lobby-ambient-orb-secondary absolute bottom-0 right-0 h-96 w-96 rounded-full blur-3xl" />
+      </div>
+
+      <div className="relative z-10 grid min-h-screen lg:grid-cols-[1.04fr_0.96fr]">
+        <section className="casino-auth-showcase relative hidden overflow-hidden lg:flex">
+          <div className="casino-auth-showcase-grid absolute inset-0 opacity-80" />
+          <div className="relative z-10 flex w-full flex-col justify-between px-12 py-12 xl:px-16">
+            <Link href="/" className="flex items-center gap-4">
+              <span className="flex h-14 w-14 items-center justify-center rounded-[1.25rem] border border-primary/20 bg-primary/12 text-primary">
+                <Spade className="h-6 w-6" />
+              </span>
+              <span>
+                <span className="block font-serif text-[2rem] font-semibold text-[var(--auth-showcase-foreground)]">TaihuCasino</span>
+                <span className="block text-sm tracking-[0.22em] text-primary/70">MEMBER CLUB</span>
+              </span>
+            </Link>
+
+            <div className="max-w-[32rem]">
+              <ShieldCheck className="mb-7 h-12 w-12 text-primary" />
+              <h1 className="font-serif text-[clamp(3rem,4.1vw,4.6rem)] font-semibold leading-[0.98] tracking-tight text-[var(--auth-showcase-foreground)]">
+                A secure way
+                <br />
+                back to play
+              </h1>
+              <p className="mt-6 text-[1.02rem] leading-8 text-[var(--auth-showcase-muted)]">
+                Reset links are time-limited. We never ask for your current password in an email.
+              </p>
+            </div>
+
+            <p className="border-t border-[var(--auth-showcase-divider)] pt-6 text-sm text-[var(--auth-showcase-muted)]">
+              Virtual tokens only. No cash-out or real-world prize redemption.
+            </p>
+          </div>
+        </section>
+
+        <section className="relative flex min-h-screen items-center justify-center px-5 py-16 sm:px-8 lg:px-10">
+          <div className="casino-auth-panel relative z-10 w-full max-w-[31rem] rounded-[2rem] p-6 sm:p-9">
+            <Link href="/" className="mb-8 flex items-center justify-center gap-3 lg:hidden">
+              <span className="flex h-11 w-11 items-center justify-center rounded-[1rem] border border-primary/20 bg-primary/12 text-primary">
+                <Spade className="h-5 w-5" />
+              </span>
+              <span className="font-serif text-2xl font-semibold text-foreground">TaihuCasino</span>
+            </Link>
+
+            <div className="text-center">
+              <h2 className="font-serif text-[2.45rem] font-semibold tracking-tight text-foreground">{title}</h2>
+              <p className="mt-3 text-base leading-7 text-[var(--auth-soft-text)]">{description}</p>
+            </div>
+            <div className="mt-8">{children}</div>
+          </div>
+        </section>
+      </div>
+    </main>
+  )
+}

--- a/docs/DEPLOYMENT_READINESS.md
+++ b/docs/DEPLOYMENT_READINESS.md
@@ -67,11 +67,11 @@ Optional dedicated observability secret:
 
 - `TAIHU_OBSERVABILITY_SECRET`: high-entropy server-only HMAC secret for pseudonymous user, session, and table identifiers in structured logs. If unset, the observer falls back to `TAIHU_RATE_LIMIT_SECRET` or `TAIHU_SESSION_SECRET`; when none is available in production, those hashes are omitted. Rotate deliberately because rotation changes correlation hashes. / 用于结构化日志中用户、session 与桌台伪匿名标识的服务端高熵 HMAC 密钥。未配置时会回退到 `TAIHU_RATE_LIMIT_SECRET` 或 `TAIHU_SESSION_SECRET`；生产环境三者都不存在时将省略这些哈希。轮换会改变关联哈希，必须有计划地执行。
 
-Required when registration remains enabled with Cloudflare Turnstile:
+Required when login, registration, or password recovery uses Cloudflare Turnstile:
 
-如果注册页继续启用 Cloudflare Turnstile，还需要：
+登录、注册或密码找回启用 Cloudflare Turnstile 时，还需要：
 
-- `NEXT_PUBLIC_TURNSTILE_SITE_KEY`: Turnstile site key used by the registration form. / 注册表单使用的 Turnstile site key。
+- `NEXT_PUBLIC_TURNSTILE_SITE_KEY`: Turnstile site key used by the login, registration, and password-recovery forms. / 登录、注册和密码找回表单使用的 Turnstile site key。
 
 Development-only fallback auth:
 
@@ -103,8 +103,11 @@ Environment variables alone are not enough. Before promoting a production deploy
 
 - Set the Supabase Auth Site URL to the production origin. / 将 Supabase Auth Site URL 设置为生产域名。
 - Add the production `/auth/callback` URL to the redirect allowlist. Add preview URLs if preview OAuth testing is required. / 将生产环境 `/auth/callback` 加入 redirect allowlist。如需在预览环境测试 OAuth，也加入预览 URL。
+- Configure a production SMTP provider before enabling password recovery. The built-in trial sender is rate-limited and best-effort. / 启用密码找回前配置生产 SMTP；内置试用发信服务有严格限额且不保证送达。
+- Configure the Supabase **Reset Password** email template to use `<a href="{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=recovery">Reset password</a>`. This token-hash endpoint supports links opened on a different device from the original request. / 将 Supabase **Reset Password** 邮件模板配置为上述链接；`token_hash` 确认端点支持在不同于申请设备的浏览器中打开链接。
+- Verify a successful reset and an expired-link retry on every deployed hostname. Reset emails return to `/auth/callback?next=%2Freset-password`, and the request response intentionally does not reveal whether an email is registered. / 在每个部署域名验证成功重置与过期链接重试。重置邮件会回到 `/auth/callback?next=%2Freset-password`，申请结果不会透露邮箱是否已注册。
 - Configure OAuth providers used by the login page: Google, Apple, Microsoft/Azure, Facebook, and X. Amazon is explicitly out of scope. / 配置登录页使用的 OAuth provider：Google、Apple、Microsoft/Azure、Facebook 和 X。Amazon 已明确排除在支持范围之外。
-- If registration is enabled, configure Supabase CAPTCHA/Turnstile backend settings in addition to `NEXT_PUBLIC_TURNSTILE_SITE_KEY`. The registration API passes `captchaToken` to `supabase.auth.signUp`. / 如果启用注册，除 `NEXT_PUBLIC_TURNSTILE_SITE_KEY` 外，还要配置 Supabase CAPTCHA/Turnstile 后台设置。注册 API 会把 `captchaToken` 传给 `supabase.auth.signUp`。
+- Configure Supabase CAPTCHA/Turnstile backend settings for every protected auth flow in addition to `NEXT_PUBLIC_TURNSTILE_SITE_KEY`. Login, registration, and password-recovery APIs pass `captchaToken` to Supabase Auth. / 除 `NEXT_PUBLIC_TURNSTILE_SITE_KEY` 外，还要为所有受保护的认证流程配置 Supabase CAPTCHA/Turnstile 后台设置。登录、注册和密码找回 API 都会把 `captchaToken` 传给 Supabase Auth。
 - Apply the Supabase migrations in `supabase/migrations/` before testing member, wallet, table session, ad reward, purchase, and game round APIs. / 在测试会员、钱包、桌台 session、广告奖励、购买和游戏回合 API 前，先应用 `supabase/migrations/` 中的迁移。
 - Keep `SUPABASE_SERVICE_ROLE_KEY` server-only. It is required by server-side member and wallet mutation code paths, but must never be exposed in `NEXT_PUBLIC_*` variables. / `SUPABASE_SERVICE_ROLE_KEY` 必须只存在于服务端环境。服务端会员和钱包写入路径需要它，但绝不能放进 `NEXT_PUBLIC_*` 变量。
 - Apply `20260612090000_api_abuse_protection.sql` before enabling production traffic. The application-level limiter uses a service-role-only atomic Postgres RPC and fails closed for sensitive production mutations if the limiter is unavailable. / 启用生产流量前必须应用 `20260612090000_api_abuse_protection.sql`。应用级限流使用仅限 service role 的 Postgres 原子 RPC；生产环境限流不可用时，敏感写入会 fail-closed。

--- a/lib/member-session.ts
+++ b/lib/member-session.ts
@@ -13,13 +13,43 @@ export interface RegisterMemberResult {
   session: MemberSession | null
 }
 
-export async function loginMember(account: string, password: string): Promise<MemberSession> {
+export async function requestPasswordReset(email: string, captchaToken: string) {
+  const response = await fetch("/api/auth/password-reset/request", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ email, captchaToken }),
+  })
+
+  const payload = (await response.json().catch(() => null)) as { error?: string } | null
+  if (!response.ok) {
+    throw new Error(payload?.error ?? "Unable to start password recovery.")
+  }
+}
+
+export async function updateMemberPassword(password: string) {
+  const response = await fetch("/api/auth/password-reset/update", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ password }),
+  })
+
+  const payload = (await response.json().catch(() => null)) as { error?: string } | null
+  if (!response.ok) {
+    throw new Error(payload?.error ?? "Unable to update your password.")
+  }
+}
+
+export async function loginMember(account: string, password: string, captchaToken: string): Promise<MemberSession> {
   const response = await fetch("/api/auth/login", {
     method: "POST",
     headers: {
       "content-type": "application/json",
     },
-    body: JSON.stringify({ account, password }),
+    body: JSON.stringify({ account, password, captchaToken }),
   })
 
   const payload = (await response.json().catch(() => null)) as {

--- a/lib/rate-limit-core.ts
+++ b/lib/rate-limit-core.ts
@@ -11,6 +11,8 @@ export const RATE_LIMIT_POLICIES = {
   "auth.login.failure": { limit: 5, windowSeconds: 900, failClosed: true },
   "auth.register": { limit: 5, windowSeconds: 3600, failClosed: true },
   "auth.oauth": { limit: 20, windowSeconds: 300, failClosed: true },
+  "auth.password-reset-request": { limit: 5, windowSeconds: 3600, failClosed: true },
+  "auth.password-reset-update": { limit: 5, windowSeconds: 900, failClosed: true },
   "member.game-rounds": { limit: 120, windowSeconds: 60, failClosed: true },
   "member.table-sessions": { limit: 20, windowSeconds: 300, failClosed: true },
   "member.cash-out": { limit: 10, windowSeconds: 300, failClosed: true },

--- a/lib/request-origin.ts
+++ b/lib/request-origin.ts
@@ -1,0 +1,20 @@
+export function isSameOriginRequest(request: Request) {
+  const origin = request.headers.get("origin")
+  if (!origin) return true
+
+  try {
+    const originUrl = new URL(origin)
+    const requestUrl = new URL(request.url)
+    if (originUrl.origin === requestUrl.origin) return true
+
+    const localHosts = new Set(["localhost", "127.0.0.1", "::1"])
+    return (
+      localHosts.has(originUrl.hostname) &&
+      localHosts.has(requestUrl.hostname) &&
+      originUrl.protocol === requestUrl.protocol &&
+      originUrl.port === requestUrl.port
+    )
+  } catch {
+    return false
+  }
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -33,6 +33,7 @@ export default defineConfig({
           NEXT_PUBLIC_SUPABASE_ANON_KEY: "",
           NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: "",
           NEXT_PUBLIC_SUPABASE_URL: "",
+          NEXT_PUBLIC_TURNSTILE_SITE_KEY: "e2e-turnstile-site-key",
           SUPABASE_SERVICE_ROLE_KEY: "",
           TAIHU_AUTH_ACCOUNT: "e2e@taihu.casino",
           TAIHU_AUTH_PASSWORD: "not-a-secret-e2e-password",

--- a/proxy.ts
+++ b/proxy.ts
@@ -17,6 +17,8 @@ function isPublicPath(pathname: string) {
     publicPages.has(pathname) ||
     pathname === "/login" ||
     pathname.startsWith("/login/") ||
+    pathname === "/forgot-password" ||
+    pathname === "/reset-password" ||
     pathname.startsWith("/api/") ||
     pathname.startsWith("/auth/")
   )

--- a/tests/api-security-regression.test.mjs
+++ b/tests/api-security-regression.test.mjs
@@ -38,6 +38,38 @@ test("member write APIs reject cross-origin mutations before state changes", asy
   }
 })
 
+test("password recovery forwards a Turnstile token to Supabase Auth", async () => {
+  const [form, captchaDialog, client, route] = await Promise.all([
+    source("../app/forgot-password/forgot-password-form.tsx"),
+    source("../components/captcha-dialog.tsx"),
+    source("../lib/member-session.ts"),
+    source("../app/api/auth/password-reset/request/route.ts"),
+  ])
+
+  assert.match(form, /CaptchaDialog/)
+  assert.match(captchaDialog, /NEXT_PUBLIC_TURNSTILE_SITE_KEY/)
+  assert.match(captchaDialog, /DialogContent/)
+  assert.match(form, /requestPasswordReset\(email\.trim\(\), captchaToken\)/)
+  assert.match(client, /requestPasswordReset\(email: string, captchaToken: string\)/)
+  assert.match(client, /JSON\.stringify\(\{ email, captchaToken \}\)/)
+  assert.match(route, /captchaToken/)
+  assert.match(route, /resetPasswordForEmail\(email, \{[\s\S]*?captchaToken,/)
+})
+
+test("password sign-in forwards a Turnstile token to Supabase Auth", async () => {
+  const [form, client, route] = await Promise.all([
+    source("../app/login/login-form.tsx"),
+    source("../lib/member-session.ts"),
+    source("../app/api/auth/login/route.ts"),
+  ])
+
+  assert.match(form, /loginMember\(trimmedEmail, password, activeCaptchaToken\)/)
+  assert.match(client, /loginMember\(account: string, password: string, captchaToken: string\)/)
+  assert.match(client, /JSON\.stringify\(\{ account, password, captchaToken \}\)/)
+  assert.match(route, /captchaToken/)
+  assert.match(route, /signInWithPassword\(\{[\s\S]*?options: \{ captchaToken \}/)
+})
+
 test("production-only stub credit paths cannot be bypassed into wallet crediting", async () => {
   const [memberData, stubGuard, purchaseComplete, adComplete, topup] = await Promise.all([
     source("../lib/member-data.ts"),

--- a/tests/e2e/release-gate.spec.ts
+++ b/tests/e2e/release-gate.spec.ts
@@ -59,6 +59,133 @@ test("login establishes a member session and protects account-rights APIs from a
   expect((await session.json()).session.account).toBe(testAccount.account)
 })
 
+test("login fits a normal desktop while short viewports keep natural overflow", async ({ page }) => {
+  await page.setViewportSize({ width: 1920, height: 878 })
+  await page.goto("/login")
+
+  await expect(page.getByRole("heading", { name: "Welcome Back" })).toBeVisible()
+  await expect(page.getByRole("button", { name: "Sign In", exact: true })).toBeVisible()
+
+  const desktop = await page.evaluate(() => ({
+    clientHeight: document.documentElement.clientHeight,
+    scrollHeight: document.documentElement.scrollHeight,
+    panelBottom: document.querySelector(".casino-auth-panel")?.getBoundingClientRect().bottom ?? Number.POSITIVE_INFINITY,
+  }))
+  expect(desktop.scrollHeight).toBeLessThanOrEqual(desktop.clientHeight + 1)
+  expect(desktop.panelBottom).toBeLessThanOrEqual(desktop.clientHeight)
+
+  await page.setViewportSize({ width: 1538, height: 586 })
+  const shortViewport = await page.evaluate(() => {
+    const panel = document.querySelector(".casino-auth-panel")
+    return {
+      clientHeight: document.documentElement.clientHeight,
+      scrollHeight: document.documentElement.scrollHeight,
+      panelDisplay: panel ? window.getComputedStyle(panel).display : "",
+    }
+  })
+  expect(shortViewport.scrollHeight).toBeGreaterThan(shortViewport.clientHeight)
+  expect(shortViewport.panelDisplay).toBe("block")
+})
+
+test("password recovery routes are public and validate the recovery forms", async ({ page }) => {
+  let recoveryRequest: { email?: string; captchaToken?: string } | null = null
+  await page.route("https://challenges.cloudflare.com/turnstile/v0/api.js**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/javascript",
+      body: `window.turnstile = {
+        render: (_container, options) => {
+          setTimeout(() => options.callback("e2e-turnstile-token"), 500)
+          return "e2e-widget"
+        },
+        reset: () => {},
+        remove: () => {}
+      }`,
+    })
+  })
+  await page.route("**/api/auth/password-reset/request", async (route) => {
+    recoveryRequest = route.request().postDataJSON()
+    await route.fulfill({
+      status: 202,
+      contentType: "application/json",
+      body: JSON.stringify({ message: "If an account exists for this email, a password reset link is on its way." }),
+    })
+  })
+
+  await page.goto("/login")
+  await expect(page.getByRole("link", { name: "Forgot password?" })).toHaveAttribute("href", "/forgot-password")
+
+  await page.getByRole("link", { name: "Forgot password?" }).click()
+  await expect(page.getByRole("heading", { name: "Recover access" })).toBeVisible()
+  await page.getByLabel("Email address").fill("player@example.com")
+  await page.getByRole("button", { name: "Send reset link" }).click()
+  await expect(page.getByRole("dialog", { name: "Security check" })).toBeVisible()
+  await expect(page.getByRole("heading", { name: "Check your email" })).toBeVisible()
+  await expect(page.getByText("player@example.com")).toBeVisible()
+  expect(recoveryRequest).toEqual({ email: "player@example.com", captchaToken: "e2e-turnstile-token" })
+
+  await page.goto("/reset-password")
+  await expect(page.getByRole("heading", { name: "Set a new password" })).toBeVisible()
+  await page.getByLabel("New password", { exact: true }).fill("short")
+  await page.getByLabel("Confirm new password", { exact: true }).fill("short")
+  await page.getByRole("button", { name: "Update password" }).click()
+  await expect(page.getByText("Password must be at least 8 characters.")).toBeVisible()
+
+  const invalidRequest = await page.request.post("/api/auth/password-reset/request", { data: { email: "invalid" } })
+  expect(invalidRequest.status()).toBe(400)
+  const crossOriginUpdate = await page.request.post("/api/auth/password-reset/update", {
+    headers: { origin: "https://attacker.example" },
+    data: { password: "a-valid-new-password" },
+  })
+  expect(crossOriginUpdate.status()).toBe(403)
+})
+
+test("password sign-in sends the Turnstile token with credentials", async ({ page }) => {
+  let loginRequest: { account?: string; password?: string; captchaToken?: string } | null = null
+  await page.route("https://challenges.cloudflare.com/turnstile/v0/api.js**", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/javascript",
+      body: `window.turnstile = {
+        render: (_container, options) => {
+          setTimeout(() => options.callback("e2e-login-turnstile-token"), 500)
+          return "e2e-login-widget"
+        },
+        getResponse: () => "e2e-login-turnstile-token",
+        reset: () => {},
+        remove: () => {}
+      }`,
+    })
+  })
+  await page.route("**/api/auth/login", async (route) => {
+    loginRequest = route.request().postDataJSON()
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        session: {
+          account: "demo@taihu.casino",
+          displayName: "Demo",
+          loginAt: new Date().toISOString(),
+          provider: "supabase",
+        },
+      }),
+    })
+  })
+
+  await page.goto("/login")
+  await page.getByLabel("Email Address").fill("demo@taihu.casino")
+  await page.locator("#password").fill("12345678")
+  await page.getByRole("button", { name: "Sign In", exact: true }).click()
+  await expect(page.getByRole("dialog", { name: "Security check" })).toBeVisible()
+
+  await expect.poll(() => loginRequest).toEqual({
+    account: "demo@taihu.casino",
+    password: "12345678",
+    captchaToken: "e2e-login-turnstile-token",
+  })
+})
+
 test("four core tables support buy-in, authoritative round settlement, replay safety, and cash-out", async ({ request }) => {
   await signIn(request)
 

--- a/tests/rate-limit.test.mjs
+++ b/tests/rate-limit.test.mjs
@@ -95,6 +95,8 @@ test("all required first-wave routes call the shared limiter", async () => {
     "../app/api/auth/login/route.ts",
     "../app/api/auth/register/route.ts",
     "../app/api/auth/oauth/route.ts",
+    "../app/api/auth/password-reset/request/route.ts",
+    "../app/api/auth/password-reset/update/route.ts",
     "../app/api/member/game-rounds/route.ts",
     "../app/api/member/table-sessions/route.ts",
     "../app/api/member/table-sessions/[id]/cash-out/route.ts",


### PR DESCRIPTION
## Summary / 概要

### English
- Adds a complete password-recovery UI and API flow with Supabase Auth callbacks.
- Presents CAPTCHA verification in a shared modal across sign-in, registration, and password recovery.
- Preserves the compact desktop login layout and responsive mobile behavior.

### 中文
- 新增完整的密码找回页面、API 与 Supabase Auth 回调流程。
- 登录、注册和密码找回统一使用共享 CAPTCHA 弹窗。
- 保留紧凑的桌面登录布局与移动端响应式体验。

## Changes / 改动内容

### English
- Added forgot-password and reset-password pages.
- Added password-reset request/update APIs, callback confirmation, rate limits, and same-origin protection.
- Forwarded Turnstile tokens to Supabase sign-in, registration, and password-recovery requests.
- Updated deployment documentation and release-gate coverage.

### 中文
- 新增忘记密码与重设密码页面。
- 新增密码重置申请/更新 API、回调确认、限流与同源保护。
- 将 Turnstile token 传递给 Supabase 登录、注册和密码找回请求。
- 更新部署文档与发布门禁覆盖。

## Testing / 测试情况

### English
- [x] `corepack pnpm run ci`
- [x] `corepack pnpm test:e2e` — 7 passed
- [x] Desktop browser QA at 1440x900
- [x] Mobile browser QA at 390x844
- [x] Login, forgot-password, and reset-password pages verified without horizontal overflow, framework overlays, or console errors

### 中文
- [x] 完整 CI 脚本通过
- [x] Playwright E2E 7 项全部通过
- [x] 1440x900 桌面浏览器检查通过
- [x] 390x844 移动端浏览器检查通过
- [x] 登录、忘记密码、重设密码页面均无横向溢出、框架错误覆盖层或控制台错误

## Deferred / 暂缓事项

### English
- Real Supabase SMTP delivery, reset-email template configuration, and production reset-link validation are intentionally deferred because the required external configuration is not currently available.

### 中文
- 由于当前缺少必要的外部配置，真实 Supabase SMTP 发信、重置邮件模板配置与生产重置链接验证按决定暂缓。